### PR TITLE
refactor based on purpose & video-source-type

### DIFF
--- a/app/src/main/java/com/pedro/rtmpstreamer/customexample/RtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/customexample/RtmpActivity.java
@@ -22,7 +22,7 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.Toast;
-import com.pedro.builder.rtmp.RtmpBuilder;
+import com.pedro.rtplibrary.rtmp.RtmpCamera1;
 import com.pedro.encoder.input.video.CameraOpenException;
 import com.pedro.encoder.input.video.EffectManager;
 import com.pedro.rtmpstreamer.R;
@@ -37,7 +37,7 @@ public class RtmpActivity extends AppCompatActivity
 
   private Integer[] orientations = new Integer[] { 0, 90, 180, 270 };
 
-  private RtmpBuilder rtmpBuilder;
+  private RtmpCamera1 rtmpBuilder;
   private Button bStartStop, bRecord;
   private EditText etUrl;
   private String currentDateAndTime = "";
@@ -62,7 +62,7 @@ public class RtmpActivity extends AppCompatActivity
     getSupportActionBar().setHomeButtonEnabled(true);
 
     SurfaceView surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
-    rtmpBuilder = new RtmpBuilder(surfaceView, this);
+    rtmpBuilder = new RtmpCamera1(surfaceView, this);
     prepareOptionsMenuViews();
 
     etUrl = (EditText) findViewById(R.id.et_rtp_url);

--- a/app/src/main/java/com/pedro/rtmpstreamer/customexample/RtspActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/customexample/RtspActivity.java
@@ -22,7 +22,7 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.Spinner;
 import android.widget.Toast;
-import com.pedro.builder.rtsp.RtspBuilder;
+import com.pedro.rtplibrary.rtsp.RtspCamera1;
 import com.pedro.encoder.input.video.CameraOpenException;
 import com.pedro.encoder.input.video.EffectManager;
 import com.pedro.rtmpstreamer.R;
@@ -38,7 +38,7 @@ public class RtspActivity extends AppCompatActivity
 
   private Integer[] orientations = new Integer[] { 0, 90, 180, 270 };
 
-  private RtspBuilder rtspBuilder;
+  private RtspCamera1 rtspBuilder;
   private SurfaceView surfaceView;
   private Button bStartStop, bRecord;
   private EditText etUrl;
@@ -65,7 +65,7 @@ public class RtspActivity extends AppCompatActivity
     getSupportActionBar().setHomeButtonEnabled(true);
 
     surfaceView = (SurfaceView) findViewById(R.id.surfaceView);
-    rtspBuilder = new RtspBuilder(surfaceView, Protocol.TCP, this);
+    rtspBuilder = new RtspCamera1(surfaceView, Protocol.TCP, this);
     prepareOptionsMenuViews();
 
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
@@ -210,9 +210,9 @@ public class RtspActivity extends AppCompatActivity
         if (!rtspBuilder.isStreaming()) {
           bStartStop.setText(getResources().getString(R.string.stop_button));
           if (rbTcp.isChecked()) {
-            rtspBuilder = new RtspBuilder(surfaceView, Protocol.TCP, this);
+            rtspBuilder = new RtspCamera1(surfaceView, Protocol.TCP, this);
           } else {
-            rtspBuilder = new RtspBuilder(surfaceView, Protocol.UDP, this);
+            rtspBuilder = new RtspCamera1(surfaceView, Protocol.UDP, this);
           }
           String resolution =
               rtspBuilder.getResolutions().get(spResolution.getSelectedItemPosition());

--- a/app/src/main/java/com/pedro/rtmpstreamer/defaultexample/ExampleRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/defaultexample/ExampleRtmpActivity.java
@@ -8,7 +8,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
-import com.pedro.builder.rtmp.RtmpBuilder;
+import com.pedro.rtplibrary.rtmp.RtmpCamera1;
 import com.pedro.rtmpstreamer.R;
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 
@@ -20,7 +20,7 @@ import net.ossrs.rtmp.ConnectCheckerRtmp;
 public class ExampleRtmpActivity extends AppCompatActivity
     implements ConnectCheckerRtmp, View.OnClickListener {
 
-  private RtmpBuilder rtmpBuilder;
+  private RtmpCamera1 rtmpBuilder;
   private Button button;
   private EditText etUrl;
 
@@ -34,7 +34,7 @@ public class ExampleRtmpActivity extends AppCompatActivity
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtmp);
-    rtmpBuilder = new RtmpBuilder(surfaceView, this);
+    rtmpBuilder = new RtmpCamera1(surfaceView, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/defaultexample/ExampleRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/defaultexample/ExampleRtspActivity.java
@@ -8,7 +8,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
-import com.pedro.builder.rtsp.RtspBuilder;
+import com.pedro.rtplibrary.rtsp.RtspCamera1;
 import com.pedro.rtmpstreamer.R;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
@@ -21,7 +21,7 @@ import com.pedro.rtsp.utils.ConnectCheckerRtsp;
 public class ExampleRtspActivity extends AppCompatActivity
     implements ConnectCheckerRtsp, View.OnClickListener {
 
-  private RtspBuilder rtspBuilder;
+  private RtspCamera1 rtspBuilder;
   private Button button;
   private EditText etUrl;
 
@@ -35,7 +35,7 @@ public class ExampleRtspActivity extends AppCompatActivity
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtsp);
-    rtspBuilder = new RtspBuilder(surfaceView, Protocol.TCP, this);
+    rtspBuilder = new RtspCamera1(surfaceView, Protocol.TCP, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/displayexample/DisplayRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/displayexample/DisplayRtmpActivity.java
@@ -10,14 +10,14 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
-import com.pedro.builder.rtmp.RtmpBuilderDisplay;
+import com.pedro.rtplibrary.rtmp.RtmpDisplay;
 import com.pedro.rtmpstreamer.R;
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class DisplayRtmpActivity extends AppCompatActivity implements ConnectCheckerRtmp, View.OnClickListener {
 
-  private RtmpBuilderDisplay rtmpBuilderDisplay;
+  private RtmpDisplay rtmpBuilderDisplay;
   private Button button;
   private EditText etUrl;
   private final int REQUEST_CODE = 1;
@@ -31,7 +31,7 @@ public class DisplayRtmpActivity extends AppCompatActivity implements ConnectChe
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtmp);
-    rtmpBuilderDisplay = new RtmpBuilderDisplay(this, this);
+    rtmpBuilderDisplay = new RtmpDisplay(this, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/displayexample/DisplayRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/displayexample/DisplayRtspActivity.java
@@ -10,7 +10,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
-import com.pedro.builder.rtsp.RtspBuilderDisplay;
+import com.pedro.rtplibrary.rtsp.RtspDisplay;
 import com.pedro.rtmpstreamer.R;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
@@ -18,7 +18,7 @@ import com.pedro.rtsp.utils.ConnectCheckerRtsp;
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
 public class DisplayRtspActivity extends AppCompatActivity implements ConnectCheckerRtsp, View.OnClickListener {
 
-  private RtspBuilderDisplay rtspBuilderDisplay;
+  private RtspDisplay rtspBuilderDisplay;
   private Button button;
   private EditText etUrl;
   private final int REQUEST_CODE = 1;
@@ -32,7 +32,7 @@ public class DisplayRtspActivity extends AppCompatActivity implements ConnectChe
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtsp);
-    rtspBuilderDisplay = new RtspBuilderDisplay(this, Protocol.TCP, this);
+    rtspBuilderDisplay = new RtspDisplay(this, Protocol.TCP, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/filestreamexample/RtmpFromFileActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/filestreamexample/RtmpFromFileActivity.java
@@ -10,7 +10,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
-import com.pedro.builder.rtmp.RtmpBuilderFromFile;
+import com.pedro.rtplibrary.rtmp.RtmpFromFile;
 import com.pedro.encoder.input.decoder.VideoDecoderInterface;
 import com.pedro.rtmpstreamer.R;
 import java.io.IOException;
@@ -20,7 +20,7 @@ import net.ossrs.rtmp.ConnectCheckerRtmp;
 public class RtmpFromFileActivity extends AppCompatActivity
     implements ConnectCheckerRtmp, View.OnClickListener, VideoDecoderInterface {
 
-  private RtmpBuilderFromFile rtmpBuilderFromFile;
+  private RtmpFromFile rtmpBuilderFromFile;
   private Button button, bSelectFile;
   private EditText etUrl;
   private TextView tvFile;
@@ -37,7 +37,7 @@ public class RtmpFromFileActivity extends AppCompatActivity
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtmp);
     tvFile = (TextView) findViewById(R.id.tv_file);
-    rtmpBuilderFromFile = new RtmpBuilderFromFile(this, this);
+    rtmpBuilderFromFile = new RtmpFromFile(this, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/filestreamexample/RtspFromFileActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/filestreamexample/RtspFromFileActivity.java
@@ -10,7 +10,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
-import com.pedro.builder.rtsp.RtspBuilderFromFile;
+import com.pedro.rtplibrary.rtsp.RtspFromFile;
 import com.pedro.encoder.input.decoder.VideoDecoderInterface;
 import com.pedro.rtmpstreamer.R;
 import com.pedro.rtsp.rtsp.Protocol;
@@ -21,7 +21,7 @@ import java.io.IOException;
 public class RtspFromFileActivity extends AppCompatActivity
     implements ConnectCheckerRtsp, View.OnClickListener, VideoDecoderInterface {
 
-  private RtspBuilderFromFile rtspBuilderFromFile;
+  private RtspFromFile rtspBuilderFromFile;
   private Button button, bSelectFile;
   private EditText etUrl;
   private TextView tvFile;
@@ -38,7 +38,7 @@ public class RtspFromFileActivity extends AppCompatActivity
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtsp);
     tvFile = (TextView) findViewById(R.id.tv_file);
-    rtspBuilderFromFile = new RtspBuilderFromFile(Protocol.TCP, this, this);
+    rtspBuilderFromFile = new RtspFromFile(Protocol.TCP, this, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/surfacemodeexample/SurfaceModeRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/surfacemodeexample/SurfaceModeRtmpActivity.java
@@ -10,7 +10,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
-import com.pedro.builder.rtmp.RtmpBuilderSurfaceMode;
+import com.pedro.rtplibrary.rtmp.RtmpCamera2;
 import com.pedro.rtmpstreamer.R;
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 
@@ -21,7 +21,7 @@ import net.ossrs.rtmp.ConnectCheckerRtmp;
 public class SurfaceModeRtmpActivity extends AppCompatActivity
     implements ConnectCheckerRtmp, View.OnClickListener {
 
-  private RtmpBuilderSurfaceMode rtmpBuilderSurfaceMode;
+  private RtmpCamera2 rtmpBuilderSurfaceMode;
   private Button button;
   private EditText etUrl;
 
@@ -35,7 +35,7 @@ public class SurfaceModeRtmpActivity extends AppCompatActivity
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtmp);
-    rtmpBuilderSurfaceMode = new RtmpBuilderSurfaceMode(surfaceView, this);
+    rtmpBuilderSurfaceMode = new RtmpCamera2(surfaceView, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/surfacemodeexample/SurfaceModeRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/surfacemodeexample/SurfaceModeRtspActivity.java
@@ -10,7 +10,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
-import com.pedro.builder.rtsp.RtspBuilderSurfaceMode;
+import com.pedro.rtplibrary.rtsp.RtspCamera2;
 import com.pedro.rtmpstreamer.R;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
@@ -22,7 +22,7 @@ import com.pedro.rtsp.utils.ConnectCheckerRtsp;
 public class SurfaceModeRtspActivity extends AppCompatActivity
     implements ConnectCheckerRtsp, View.OnClickListener {
 
-  private RtspBuilderSurfaceMode rtspBuilderSurfaceMode;
+  private RtspCamera2 rtspBuilderSurfaceMode;
   private Button button;
   private EditText etUrl;
 
@@ -36,7 +36,7 @@ public class SurfaceModeRtspActivity extends AppCompatActivity
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtsp);
-    rtspBuilderSurfaceMode = new RtspBuilderSurfaceMode(surfaceView, Protocol.TCP, this);
+    rtspBuilderSurfaceMode = new RtspCamera2(surfaceView, Protocol.TCP, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/texturemodeexample/TextureModeRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/texturemodeexample/TextureModeRtmpActivity.java
@@ -11,7 +11,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
 
-import com.pedro.builder.rtmp.RtmpBuilderSurfaceMode;
+import com.pedro.rtplibrary.rtmp.RtmpCamera2;
 import com.pedro.rtmpstreamer.R;
 
 import net.ossrs.rtmp.ConnectCheckerRtmp;
@@ -23,7 +23,7 @@ import net.ossrs.rtmp.ConnectCheckerRtmp;
 public class TextureModeRtmpActivity extends AppCompatActivity
     implements ConnectCheckerRtmp, View.OnClickListener {
 
-  private RtmpBuilderSurfaceMode rtmpBuilderSurfaceMode;
+  private RtmpCamera2 rtmpBuilderSurfaceMode;
   private Button button;
   private EditText etUrl;
 
@@ -37,7 +37,7 @@ public class TextureModeRtmpActivity extends AppCompatActivity
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtmp);
-    rtmpBuilderSurfaceMode = new RtmpBuilderSurfaceMode(textureView, this);
+    rtmpBuilderSurfaceMode = new RtmpCamera2(textureView, this);
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtmpstreamer/texturemodeexample/TextureModeRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtmpstreamer/texturemodeexample/TextureModeRtspActivity.java
@@ -11,7 +11,7 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
 
-import com.pedro.builder.rtsp.RtspBuilderSurfaceMode;
+import com.pedro.rtplibrary.rtsp.RtspCamera2;
 import com.pedro.rtmpstreamer.R;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
@@ -23,7 +23,7 @@ import com.pedro.rtsp.utils.ConnectCheckerRtsp;
 public class TextureModeRtspActivity extends AppCompatActivity
     implements ConnectCheckerRtsp, View.OnClickListener {
 
-  private RtspBuilderSurfaceMode rtspBuilderSurfaceMode;
+  private RtspCamera2 rtspBuilderSurfaceMode;
   private Button button;
   private EditText etUrl;
 
@@ -37,7 +37,7 @@ public class TextureModeRtspActivity extends AppCompatActivity
     button.setOnClickListener(this);
     etUrl = (EditText) findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtsp);
-    rtspBuilderSurfaceMode = new RtspBuilderSurfaceMode(textureView, Protocol.TCP, this);
+    rtspBuilderSurfaceMode = new RtspCamera2(textureView, Protocol.TCP, this);
   }
 
   @Override

--- a/app/src/main/res/layout/activity_texture_mode.xml
+++ b/app/src/main/res/layout/activity_texture_mode.xml
@@ -7,7 +7,7 @@
     tools:context=".defaultexample.ExampleRtmpActivity"
     >
 
-  <com.pedro.builder.view.AutoFitTextureView
+  <com.pedro.rtplibrary.view.AutoFitTextureView
       android:id="@+id/textureView"
       android:layout_width="match_parent"
       android:layout_height="match_parent"

--- a/builder/src/main/AndroidManifest.xml
+++ b/builder/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
 
-    package="com.pedro.builder">
+    package="com.pedro.rtplibrary">
 
   <application android:allowBackup="true" android:label="@string/app_name" android:supportsRtl="true">
 

--- a/builder/src/main/java/com/pedro/rtplibrary/DecodersTest.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/DecodersTest.java
@@ -1,4 +1,4 @@
-package com.pedro.builder;
+package com.pedro.rtplibrary;
 
 import android.media.AudioFormat;
 import android.media.AudioManager;

--- a/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
@@ -1,21 +1,24 @@
-package com.pedro.builder.rtmp;
+package com.pedro.rtplibrary.rtmp;
 
 import android.media.MediaCodec;
 import android.view.SurfaceView;
-import com.pedro.builder.base.BuilderBase;
-import java.nio.ByteBuffer;
+
+import com.pedro.rtplibrary.source.Camera1Source;
+
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 import net.ossrs.rtmp.SrsFlvMuxer;
+
+import java.nio.ByteBuffer;
 
 /**
  * Created by pedro on 25/01/17.
  */
 
-public class RtmpBuilder extends BuilderBase {
+public class RtmpCamera1 extends Camera1Source {
 
   private SrsFlvMuxer srsFlvMuxer;
 
-  public RtmpBuilder(SurfaceView surfaceView, ConnectCheckerRtmp connectChecker) {
+  public RtmpCamera1(SurfaceView surfaceView, ConnectCheckerRtmp connectChecker) {
     super(surfaceView);
     srsFlvMuxer = new SrsFlvMuxer(connectChecker);
   }

--- a/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
@@ -1,23 +1,41 @@
-package com.pedro.builder.rtmp;
+package com.pedro.rtplibrary.rtmp;
 
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
-import com.pedro.builder.base.BuilderDisplayBase;
-import java.nio.ByteBuffer;
+import android.view.SurfaceView;
+import android.view.TextureView;
+
+import com.pedro.rtplibrary.source.Camera2Source;
+
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 import net.ossrs.rtmp.SrsFlvMuxer;
 
+import java.nio.ByteBuffer;
+
 /**
- * Created by pedro on 9/08/17.
+ * Created by pedro on 6/07/17.
+ * This builder is under test, rotation only work with hardware because use encoding surface mode.
+ * This maybe don't work for synchronizations problems and you will lose audio or video channel in
+ * the stream
  */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class RtmpBuilderDisplay extends BuilderDisplayBase {
+public class RtmpCamera2 extends Camera2Source {
 
   private SrsFlvMuxer srsFlvMuxer;
 
-  public RtmpBuilderDisplay(Context context, ConnectCheckerRtmp connectChecker) {
+  public RtmpCamera2(SurfaceView surfaceView, ConnectCheckerRtmp connectChecker) {
+    super(surfaceView, surfaceView.getContext());
+    srsFlvMuxer = new SrsFlvMuxer(connectChecker);
+  }
+
+  public RtmpCamera2(TextureView textureView, ConnectCheckerRtmp connectChecker) {
+    super(textureView, textureView.getContext());
+    srsFlvMuxer = new SrsFlvMuxer(connectChecker);
+  }
+
+  public RtmpCamera2(Context context, ConnectCheckerRtmp connectChecker) {
     super(context);
     srsFlvMuxer = new SrsFlvMuxer(connectChecker);
   }
@@ -69,3 +87,4 @@ public class RtmpBuilderDisplay extends BuilderDisplayBase {
     srsFlvMuxer.sendVideo(h264Buffer, info);
   }
 }
+

--- a/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpDisplay.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpDisplay.java
@@ -1,13 +1,12 @@
-package com.pedro.builder.rtmp;
+package com.pedro.rtplibrary.rtmp;
 
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
-import android.view.SurfaceView;
-import android.view.TextureView;
 
-import com.pedro.builder.base.BuilderSurfaceModeBase;
+import com.pedro.rtplibrary.source.Display;
+import com.pedro.rtplibrary.source.DisplaySource;
 
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 import net.ossrs.rtmp.SrsFlvMuxer;
@@ -15,27 +14,14 @@ import net.ossrs.rtmp.SrsFlvMuxer;
 import java.nio.ByteBuffer;
 
 /**
- * Created by pedro on 6/07/17.
- * This builder is under test, rotation only work with hardware because use encoding surface mode.
- * This maybe don't work for synchronizations problems and you will lose audio or video channel in
- * the stream
+ * Created by pedro on 9/08/17.
  */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class RtmpBuilderSurfaceMode extends BuilderSurfaceModeBase {
+public class RtmpDisplay extends DisplaySource {
 
   private SrsFlvMuxer srsFlvMuxer;
 
-  public RtmpBuilderSurfaceMode(SurfaceView surfaceView, ConnectCheckerRtmp connectChecker) {
-    super(surfaceView, surfaceView.getContext());
-    srsFlvMuxer = new SrsFlvMuxer(connectChecker);
-  }
-
-  public RtmpBuilderSurfaceMode(TextureView textureView, ConnectCheckerRtmp connectChecker) {
-    super(textureView, textureView.getContext());
-    srsFlvMuxer = new SrsFlvMuxer(connectChecker);
-  }
-
-  public RtmpBuilderSurfaceMode(Context context, ConnectCheckerRtmp connectChecker) {
+  public RtmpDisplay(Context context, ConnectCheckerRtmp connectChecker) {
     super(context);
     srsFlvMuxer = new SrsFlvMuxer(connectChecker);
   }
@@ -87,4 +73,3 @@ public class RtmpBuilderSurfaceMode extends BuilderSurfaceModeBase {
     srsFlvMuxer.sendVideo(h264Buffer, info);
   }
 }
-

--- a/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpFromFile.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtmp/RtmpFromFile.java
@@ -1,4 +1,4 @@
-package com.pedro.builder.rtmp;
+package com.pedro.rtplibrary.rtmp;
 
 /**
  * Created by pedro on 26/06/17.
@@ -7,11 +7,15 @@ package com.pedro.builder.rtmp;
 import android.media.MediaCodec;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
-import com.pedro.builder.base.BuilderFromFileBase;
+
 import com.pedro.encoder.input.decoder.VideoDecoderInterface;
-import java.nio.ByteBuffer;
+import com.pedro.rtplibrary.source.FromFile;
+import com.pedro.rtplibrary.source.FromFileSource;
+
 import net.ossrs.rtmp.ConnectCheckerRtmp;
 import net.ossrs.rtmp.SrsFlvMuxer;
+
+import java.nio.ByteBuffer;
 
 /**
  * Created by pedro on 26/06/17.
@@ -19,12 +23,12 @@ import net.ossrs.rtmp.SrsFlvMuxer;
  * Only video is working, audio will be added when it work
  */
 @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-public class RtmpBuilderFromFile extends BuilderFromFileBase {
+public class RtmpFromFile extends FromFileSource {
 
   private SrsFlvMuxer srsFlvMuxer;
 
-  public RtmpBuilderFromFile(ConnectCheckerRtmp connectChecker,
-      VideoDecoderInterface videoDecoderInterface) {
+  public RtmpFromFile(ConnectCheckerRtmp connectChecker,
+                      VideoDecoderInterface videoDecoderInterface) {
     super(videoDecoderInterface);
     srsFlvMuxer = new SrsFlvMuxer(connectChecker);
   }

--- a/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera1.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera1.java
@@ -1,43 +1,24 @@
-package com.pedro.builder.rtsp;
+package com.pedro.rtplibrary.rtsp;
 
-import android.content.Context;
 import android.media.MediaCodec;
-import android.os.Build;
-import android.support.annotation.RequiresApi;
 import android.view.SurfaceView;
-import android.view.TextureView;
-
-import com.pedro.builder.base.BuilderSurfaceModeBase;
+import com.pedro.rtplibrary.source.Camera1Source;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.rtsp.RtspClient;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
-
 import java.nio.ByteBuffer;
 
 /**
- * Created by pedro on 4/06/17.
- * This builder is under test, rotation only work with hardware because use encoding surface mode.
+ * Created by pedro on 10/02/17.
  */
-@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class RtspBuilderSurfaceMode extends BuilderSurfaceModeBase {
+
+public class RtspCamera1 extends Camera1Source {
 
   private RtspClient rtspClient;
 
-  public RtspBuilderSurfaceMode(SurfaceView surfaceView, Protocol protocol,
-      ConnectCheckerRtsp connectCheckerRtsp) {
-    super(surfaceView, surfaceView.getContext());
-    rtspClient = new RtspClient(connectCheckerRtsp, protocol);
-  }
-
-  public RtspBuilderSurfaceMode(TextureView textureView, Protocol protocol,
-      ConnectCheckerRtsp connectCheckerRtsp) {
-    super(textureView, textureView.getContext());
-    rtspClient = new RtspClient(connectCheckerRtsp, protocol);
-  }
-
-  public RtspBuilderSurfaceMode(Context context, Protocol protocol,
-      ConnectCheckerRtsp connectCheckerRtsp) {
-    super(context);
+  public RtspCamera1(SurfaceView surfaceView, Protocol protocol,
+                     ConnectCheckerRtsp connectCheckerRtsp) {
+    super(surfaceView);
     rtspClient = new RtspClient(connectCheckerRtsp, protocol);
   }
 
@@ -87,4 +68,3 @@ public class RtspBuilderSurfaceMode extends BuilderSurfaceModeBase {
     rtspClient.sendVideo(h264Buffer, info);
   }
 }
-

--- a/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
@@ -1,24 +1,43 @@
-package com.pedro.builder.rtsp;
+package com.pedro.rtplibrary.rtsp;
 
+import android.content.Context;
 import android.media.MediaCodec;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
 import android.view.SurfaceView;
-import com.pedro.builder.base.BuilderBase;
+import android.view.TextureView;
+
+import com.pedro.rtplibrary.source.Camera2Source;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.rtsp.RtspClient;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
+
 import java.nio.ByteBuffer;
 
 /**
- * Created by pedro on 10/02/17.
+ * Created by pedro on 4/06/17.
+ * This builder is under test, rotation only work with hardware because use encoding surface mode.
  */
-
-public class RtspBuilder extends BuilderBase {
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public class RtspCamera2 extends Camera2Source {
 
   private RtspClient rtspClient;
 
-  public RtspBuilder(SurfaceView surfaceView, Protocol protocol,
-      ConnectCheckerRtsp connectCheckerRtsp) {
-    super(surfaceView);
+  public RtspCamera2(SurfaceView surfaceView, Protocol protocol,
+                     ConnectCheckerRtsp connectCheckerRtsp) {
+    super(surfaceView, surfaceView.getContext());
+    rtspClient = new RtspClient(connectCheckerRtsp, protocol);
+  }
+
+  public RtspCamera2(TextureView textureView, Protocol protocol,
+                     ConnectCheckerRtsp connectCheckerRtsp) {
+    super(textureView, textureView.getContext());
+    rtspClient = new RtspClient(connectCheckerRtsp, protocol);
+  }
+
+  public RtspCamera2(Context context, Protocol protocol,
+                     ConnectCheckerRtsp connectCheckerRtsp) {
+    super(context);
     rtspClient = new RtspClient(connectCheckerRtsp, protocol);
   }
 
@@ -68,3 +87,4 @@ public class RtspBuilder extends BuilderBase {
     rtspClient.sendVideo(h264Buffer, info);
   }
 }
+

--- a/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspDisplay.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspDisplay.java
@@ -1,10 +1,10 @@
-package com.pedro.builder.rtsp;
+package com.pedro.rtplibrary.rtsp;
 
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
-import com.pedro.builder.base.BuilderDisplayBase;
+import com.pedro.rtplibrary.source.DisplaySource;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.rtsp.RtspClient;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
@@ -14,12 +14,12 @@ import java.nio.ByteBuffer;
  * Created by pedro on 9/08/17.
  */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public class RtspBuilderDisplay extends BuilderDisplayBase {
+public class RtspDisplay extends DisplaySource {
 
   private RtspClient rtspClient;
 
-  public RtspBuilderDisplay(Context context, Protocol protocol,
-      ConnectCheckerRtsp connectCheckerRtsp) {
+  public RtspDisplay(Context context, Protocol protocol,
+                     ConnectCheckerRtsp connectCheckerRtsp) {
     super(context);
     rtspClient = new RtspClient(connectCheckerRtsp, protocol);
   }

--- a/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspFromFile.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/rtsp/RtspFromFile.java
@@ -1,9 +1,9 @@
-package com.pedro.builder.rtsp;
+package com.pedro.rtplibrary.rtsp;
 
 import android.media.MediaCodec;
 import android.os.Build;
 import android.support.annotation.RequiresApi;
-import com.pedro.builder.base.BuilderFromFileBase;
+import com.pedro.rtplibrary.source.FromFileSource;
 import com.pedro.encoder.input.decoder.VideoDecoderInterface;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.rtsp.RtspClient;
@@ -16,12 +16,12 @@ import java.nio.ByteBuffer;
  * Only video is working, audio will be added when it work
  */
 @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-public class RtspBuilderFromFile extends BuilderFromFileBase {
+public class RtspFromFile extends FromFileSource {
 
   private RtspClient rtspClient;
 
-  public RtspBuilderFromFile(Protocol protocol, ConnectCheckerRtsp connectCheckerRtsp,
-      VideoDecoderInterface videoDecoderInterface) {
+  public RtspFromFile(Protocol protocol, ConnectCheckerRtsp connectCheckerRtsp,
+                      VideoDecoderInterface videoDecoderInterface) {
     super(videoDecoderInterface);
     rtspClient = new RtspClient(connectCheckerRtsp, protocol);
   }

--- a/builder/src/main/java/com/pedro/rtplibrary/source/Camera1Source.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/source/Camera1Source.java
@@ -1,4 +1,4 @@
-package com.pedro.builder.base;
+package com.pedro.rtplibrary.source;
 
 import android.graphics.ImageFormat;
 import android.hardware.Camera;
@@ -28,7 +28,7 @@ import java.util.List;
  * Created by pedro on 7/07/17.
  */
 
-public abstract class BuilderBase
+public abstract class Camera1Source
     implements GetAacData, GetCameraData, GetH264Data, GetMicrophoneData {
 
   private Camera1ApiManager cameraManager;
@@ -45,7 +45,7 @@ public abstract class BuilderBase
   private MediaFormat videoFormat;
   private MediaFormat audioFormat;
 
-  public BuilderBase(SurfaceView surfaceView) {
+  public Camera1Source(SurfaceView surfaceView) {
     cameraManager = new Camera1ApiManager(surfaceView, this);
     videoEncoder = new VideoEncoder(this);
     microphoneManager = new MicrophoneManager(this);

--- a/builder/src/main/java/com/pedro/rtplibrary/source/Camera2Source.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/source/Camera2Source.java
@@ -1,4 +1,4 @@
-package com.pedro.builder.base;
+package com.pedro.rtplibrary.source;
 
 import android.content.Context;
 import android.graphics.ImageFormat;
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
  * Created by pedro on 7/07/17.
  */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public abstract class BuilderSurfaceModeBase
+public abstract class Camera2Source
     implements GetAacData, GetCameraData, GetH264Data, GetMicrophoneData {
 
   protected Context context;
@@ -48,7 +48,7 @@ public abstract class BuilderSurfaceModeBase
   private MediaFormat videoFormat;
   private MediaFormat audioFormat;
 
-  public BuilderSurfaceModeBase(SurfaceView surfaceView, Context context) {
+  public Camera2Source(SurfaceView surfaceView, Context context) {
     this.surfaceView = surfaceView;
     this.context = context;
     videoEncoder = new VideoEncoder(this);
@@ -57,7 +57,7 @@ public abstract class BuilderSurfaceModeBase
     streaming = false;
   }
 
-  public BuilderSurfaceModeBase(TextureView textureView, Context context) {
+  public Camera2Source(TextureView textureView, Context context) {
     this.textureView = textureView;
     this.context = context;
     videoEncoder = new VideoEncoder(this);
@@ -66,7 +66,7 @@ public abstract class BuilderSurfaceModeBase
     streaming = false;
   }
 
-  public BuilderSurfaceModeBase(Context context) {
+  public Camera2Source(Context context) {
     this.context = context;
     this.textureView = null;
     videoEncoder = new VideoEncoder(this);

--- a/builder/src/main/java/com/pedro/rtplibrary/source/DisplaySource.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/source/DisplaySource.java
@@ -1,4 +1,4 @@
-package com.pedro.builder.base;
+package com.pedro.rtplibrary.source;
 
 import android.content.Context;
 import android.content.Intent;
@@ -15,8 +15,6 @@ import com.pedro.encoder.audio.AudioEncoder;
 import com.pedro.encoder.audio.GetAacData;
 import com.pedro.encoder.input.audio.GetMicrophoneData;
 import com.pedro.encoder.input.audio.MicrophoneManager;
-import com.pedro.encoder.input.video.Camera2ApiManager;
-import com.pedro.encoder.input.video.CameraOpenException;
 import com.pedro.encoder.input.video.GetCameraData;
 import com.pedro.encoder.video.FormatVideoEncoder;
 import com.pedro.encoder.video.GetH264Data;
@@ -30,7 +28,7 @@ import static android.content.Context.MEDIA_PROJECTION_SERVICE;
  * Created by pedro on 9/08/17.
  */
 @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-public abstract class BuilderDisplayBase
+public abstract class DisplaySource
     implements GetAacData, GetCameraData, GetH264Data, GetMicrophoneData {
 
   protected Context context;
@@ -51,7 +49,7 @@ public abstract class BuilderDisplayBase
   private MediaFormat audioFormat;
   private int dpi = 320;
 
-  public BuilderDisplayBase(Context context) {
+  public DisplaySource(Context context) {
     this.context = context;
     mediaProjectionManager =
         ((MediaProjectionManager) context.getSystemService(MEDIA_PROJECTION_SERVICE));

--- a/builder/src/main/java/com/pedro/rtplibrary/source/FromFileSource.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/source/FromFileSource.java
@@ -1,4 +1,4 @@
-package com.pedro.builder.base;
+package com.pedro.rtplibrary.source;
 
 import android.media.MediaCodec;
 import android.media.MediaFormat;
@@ -19,7 +19,7 @@ import java.nio.ByteBuffer;
  */
 
 @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-public abstract class BuilderFromFileBase implements GetCameraData, GetH264Data {
+public abstract class FromFileSource implements GetCameraData, GetH264Data {
 
   protected VideoEncoder videoEncoder;
   private boolean streaming;
@@ -34,7 +34,7 @@ public abstract class BuilderFromFileBase implements GetCameraData, GetH264Data 
   private MediaPlayer mediaPlayer;
   //private VideoDecoder videoDecoder;
 
-  public BuilderFromFileBase(VideoDecoderInterface videoDecoderInterface) {
+  public FromFileSource(VideoDecoderInterface videoDecoderInterface) {
     this.videoDecoderInterface = videoDecoderInterface;
     videoEncoder = new VideoEncoder(this);
     //videoDecoder = new VideoDecoder(videoDecoderInterface);

--- a/builder/src/main/java/com/pedro/rtplibrary/view/AutoFitTextureView.java
+++ b/builder/src/main/java/com/pedro/rtplibrary/view/AutoFitTextureView.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.pedro.builder.view;
+package com.pedro.rtplibrary.view;
 
 import android.content.Context;
 import android.util.AttributeSet;


### PR DESCRIPTION
Refactored `builder` package and classes 
* approach is based on `video-source-type` and `purpose` as previous implementations names lacked description. 
* previous implementation names implied that they were based on the `Builder` pattern
  * the `base` classes configure and manage: 
    * Camera (1 or 2), Mic Managers, Video - Audio Encoders and Muxer 
* package name is `rtplibrary`  this clarifyies what it is and its purpose