### PR TITLE
prevent move object outside

### DIFF
--- a/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtmpActivity.java
@@ -287,6 +287,7 @@ public class OpenGlRtmpActivity extends AppCompatActivity
         rtmpCamera1.getStreamHeight());
     imageObjectFilterRender.setPosition(TranslateTo.RIGHT);
     spriteGestureController.setBaseObjectFilterRender(imageObjectFilterRender); //Optional
+    spriteGestureController.setPreventMoveOutside(false); //Optional
   }
 
   private void setGifToStream() {

--- a/encoder/src/main/java/com/pedro/encoder/input/gl/SpriteGestureController.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/SpriteGestureController.java
@@ -13,6 +13,7 @@ public class SpriteGestureController {
 
   private BaseObjectFilterRender baseObjectFilterRender;
   private float lastDistance;
+  private boolean preventMoveOutside = true;
 
   public SpriteGestureController() {
   }
@@ -27,6 +28,10 @@ public class SpriteGestureController {
 
   public void setBaseObjectFilterRender(BaseObjectFilterRender baseObjectFilterRender) {
     this.baseObjectFilterRender = baseObjectFilterRender;
+  }
+
+  public void setPreventMoveOutside(boolean preventMoveOutside) {
+    this.preventMoveOutside = preventMoveOutside;
   }
 
   public boolean spriteTouched(View view, MotionEvent motionEvent) {
@@ -46,7 +51,25 @@ public class SpriteGestureController {
       float xPercent = motionEvent.getX() * 100 / view.getWidth();
       float yPercent = motionEvent.getY() * 100 / view.getHeight();
       PointF scale = baseObjectFilterRender.getScale();
-      baseObjectFilterRender.setPosition(xPercent - scale.x / 2f, yPercent - scale.y / 2f);
+      if(this.preventMoveOutside) {
+        float x = xPercent - scale.x / 2.0F;
+        float y = yPercent - scale.y / 2.0F;
+        if( x < 0 ) {
+          x = 0;
+        }
+        if( x + scale.x > 100.0F ) {
+          x = 100.0F - scale.x;
+        }
+        if( y < 0 ) {
+          y = 0;
+        }
+        if( y + scale.y > 100.0F ) {
+          y = 100.0F - scale.y;
+        }
+        this.baseObjectFilterRender.setPosition(x, y);
+      } else {
+        baseObjectFilterRender.setPosition(xPercent - scale.x / 2f, yPercent - scale.y / 2f);
+      }
     }
   }
 


### PR DESCRIPTION
Added option in SpriteGestureController (default on).
In the demo app, you can freely move Image but Text and Gif only in view boundaries