### PR TITLE
Add stats for dropped frames, reset functions for counters & FLV bugfix

### DIFF
--- a/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
@@ -140,8 +140,12 @@ public class SrsFlvMuxer {
     connected = false;
     mVideoSequenceHeader = null;
     mAudioSequenceHeader = null;
-    mVideoFramesSent = 0;
-    mAudioFramesSent = 0;
+
+    resetSentAudioFrames();
+    resetSentVideoFrames();
+    resetDroppedAudioFrames();
+    resetDroppedVideoFrames();
+    
     connectChecker.onDisconnectRtmp();
     Log.i(TAG, "worker: disconnect ok.");
   }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
@@ -65,17 +65,17 @@ public class RtmpCamera1 extends Camera1Base {
     srsFlvMuxer.resizeFlvTagCache(newSize);
   }
 
-  public int getFlvTagCacheSize() {
-    return srsFlvMuxer.getFlvTagCacheSize();
-  }
+  public int getFlvTagCacheSize()       { return srsFlvMuxer.getFlvTagCacheSize();    }
 
-  public long getSentAudioFrames() {
-    return srsFlvMuxer.getSentAudioFrames();
-  }
+  public long getSentAudioFrames()      { return srsFlvMuxer.getSentAudioFrames();    }
+  public long getSentVideoFrames()      { return srsFlvMuxer.getSentVideoFrames();    }
+  public long getDroppedAudioFrames()   { return srsFlvMuxer.getDroppedAudioFrames(); }
+  public long getDroppedVideoFrames()   { return srsFlvMuxer.getDroppedVideoFrames(); }
 
-  public long getSentVideoFrames() {
-    return srsFlvMuxer.getSentVideoFrames();
-  }
+  public void resetSentAudioFrames()    { srsFlvMuxer.resetSentAudioFrames();         }
+  public void resetSentVideoFrames()    { srsFlvMuxer.resetSentVideoFrames();         }
+  public void resetDroppedAudioFrames() { srsFlvMuxer.resetDroppedAudioFrames();      }
+  public void resetDroppedVideoFrames() { srsFlvMuxer.resetDroppedVideoFrames();      }
 
   @Override
   public void setAuthorization(String user, String password) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
@@ -65,17 +65,17 @@ public class RtmpCamera2 extends Camera2Base {
     srsFlvMuxer.resizeFlvTagCache(newSize);
   }
 
-  public int getFlvTagCacheSize(){ return srsFlvMuxer != null ? srsFlvMuxer.getFlvTagCacheSize() : -1; }
+  public int getFlvTagCacheSize()       { return srsFlvMuxer.getFlvTagCacheSize();    }
 
-  public long getSentAudioFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getSentAudioFrames() : -1; }
-  public long getSentVideoFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getSentVideoFrames() : -1; }
-  public long getDroppedAudioFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getDroppedAudioFrames() : -1; }
-  public long getDroppedVideoFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getDroppedVideoFrames() : -1; }
+  public long getSentAudioFrames()      { return srsFlvMuxer.getSentAudioFrames();    }
+  public long getSentVideoFrames()      { return srsFlvMuxer.getSentVideoFrames();    }
+  public long getDroppedAudioFrames()   { return srsFlvMuxer.getDroppedAudioFrames(); }
+  public long getDroppedVideoFrames()   { return srsFlvMuxer.getDroppedVideoFrames(); }
 
-  public void resetSentAudioFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetSentAudioFrames(); } }
-  public void resetSentVideoFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetSentVideoFrames(); } }
-  public void resetDroppedAudioFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetDroppedAudioFrames(); } }
-  public void resetDroppedVideoFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetDroppedVideoFrames(); } }
+  public void resetSentAudioFrames()    { srsFlvMuxer.resetSentAudioFrames();         }
+  public void resetSentVideoFrames()    { srsFlvMuxer.resetSentVideoFrames();         }
+  public void resetDroppedAudioFrames() { srsFlvMuxer.resetDroppedAudioFrames();      }
+  public void resetDroppedVideoFrames() { srsFlvMuxer.resetDroppedVideoFrames();      }
 
   @Override
   public void setAuthorization(String user, String password) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
@@ -65,17 +65,17 @@ public class RtmpCamera2 extends Camera2Base {
     srsFlvMuxer.resizeFlvTagCache(newSize);
   }
 
-  public int getFlvTagCacheSize() {
-    return srsFlvMuxer.getFlvTagCacheSize();
-  }
+  public int getFlvTagCacheSize(){ return srsFlvMuxer != null ? srsFlvMuxer.getFlvTagCacheSize() : -1; }
 
-  public long getSentAudioFrames() {
-    return srsFlvMuxer.getSentAudioFrames();
-  }
+  public long getSentAudioFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getSentAudioFrames() : -1; }
+  public long getSentVideoFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getSentVideoFrames() : -1; }
+  public long getDroppedAudioFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getDroppedAudioFrames() : -1; }
+  public long getDroppedVideoFrames() { return srsFlvMuxer != null ? srsFlvMuxer.getDroppedVideoFrames() : -1; }
 
-  public long getSentVideoFrames() {
-    return srsFlvMuxer.getSentVideoFrames();
-  }
+  public void resetSentAudioFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetSentAudioFrames(); } }
+  public void resetSentVideoFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetSentVideoFrames(); } }
+  public void resetDroppedAudioFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetDroppedAudioFrames(); } }
+  public void resetDroppedVideoFrames() { if(srsFlvMuxer != null) { srsFlvMuxer.resetDroppedVideoFrames(); } }
 
   @Override
   public void setAuthorization(String user, String password) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpDisplay.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpDisplay.java
@@ -41,17 +41,17 @@ public class RtmpDisplay extends DisplayBase {
     srsFlvMuxer.resizeFlvTagCache(newSize);
   }
 
-  public int getFlvTagCacheSize() {
-    return srsFlvMuxer.getFlvTagCacheSize();
-  }
+  public int getFlvTagCacheSize()       { return srsFlvMuxer.getFlvTagCacheSize();    }
 
-  public long getSentAudioFrames() {
-    return srsFlvMuxer.getSentAudioFrames();
-  }
+  public long getSentAudioFrames()      { return srsFlvMuxer.getSentAudioFrames();    }
+  public long getSentVideoFrames()      { return srsFlvMuxer.getSentVideoFrames();    }
+  public long getDroppedAudioFrames()   { return srsFlvMuxer.getDroppedAudioFrames(); }
+  public long getDroppedVideoFrames()   { return srsFlvMuxer.getDroppedVideoFrames(); }
 
-  public long getSentVideoFrames() {
-    return srsFlvMuxer.getSentVideoFrames();
-  }
+  public void resetSentAudioFrames()    { srsFlvMuxer.resetSentAudioFrames();         }
+  public void resetSentVideoFrames()    { srsFlvMuxer.resetSentVideoFrames();         }
+  public void resetDroppedAudioFrames() { srsFlvMuxer.resetDroppedAudioFrames();      }
+  public void resetDroppedVideoFrames() { srsFlvMuxer.resetDroppedVideoFrames();      }
 
   @Override
   public void setAuthorization(String user, String password) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpFromFile.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpFromFile.java
@@ -64,17 +64,17 @@ public class RtmpFromFile extends FromFileBase {
     srsFlvMuxer.resizeFlvTagCache(newSize);
   }
 
-  public int getFlvTagCacheSize() {
-    return srsFlvMuxer.getFlvTagCacheSize();
-  }
+  public int getFlvTagCacheSize()       { return srsFlvMuxer.getFlvTagCacheSize();    }
 
-  public long getSentAudioFrames() {
-    return srsFlvMuxer.getSentAudioFrames();
-  }
+  public long getSentAudioFrames()      { return srsFlvMuxer.getSentAudioFrames();    }
+  public long getSentVideoFrames()      { return srsFlvMuxer.getSentVideoFrames();    }
+  public long getDroppedAudioFrames()   { return srsFlvMuxer.getDroppedAudioFrames(); }
+  public long getDroppedVideoFrames()   { return srsFlvMuxer.getDroppedVideoFrames(); }
 
-  public long getSentVideoFrames() {
-    return srsFlvMuxer.getSentVideoFrames();
-  }
+  public void resetSentAudioFrames()    { srsFlvMuxer.resetSentAudioFrames();         }
+  public void resetSentVideoFrames()    { srsFlvMuxer.resetSentVideoFrames();         }
+  public void resetDroppedAudioFrames() { srsFlvMuxer.resetDroppedAudioFrames();      }
+  public void resetDroppedVideoFrames() { srsFlvMuxer.resetDroppedVideoFrames();      }
 
   @Override
   public void setAuthorization(String user, String password) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpOnlyAudio.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpOnlyAudio.java
@@ -25,13 +25,13 @@ public class RtmpOnlyAudio extends OnlyAudioBase {
     srsFlvMuxer.resizeFlvTagCache(newSize);
   }
 
-  public int getFlvTagCacheSize() {
-    return srsFlvMuxer.getFlvTagCacheSize();
-  }
+  public int getFlvTagCacheSize()       { return srsFlvMuxer.getFlvTagCacheSize();    }
 
-  public long getSentAudioFrames() {
-    return srsFlvMuxer.getSentAudioFrames();
-  }
+  public long getSentAudioFrames()      { return srsFlvMuxer.getSentAudioFrames();    }
+  public long getDroppedAudioFrames()   { return srsFlvMuxer.getDroppedAudioFrames(); }
+
+  public void resetSentAudioFrames()    { srsFlvMuxer.resetSentAudioFrames();         }
+  public void resetDroppedAudioFrames() { srsFlvMuxer.resetDroppedAudioFrames();      }
 
   @Override
   public void setAuthorization(String user, String password) {


### PR DESCRIPTION
See this [commit](https://github.com/pedroSG94/rtmp-rtsp-stream-client-java/commit/b5b818a4c5ab094e81a57064f56c6a0d7f78f64a)

Now uses .poll() instead of .take() on the LinkedBlockingQueue. I haven't noticed any issues with this, but this could require testing on different units (tested and works on SM930, Samsung Galaxy 7, Android 8)