### PR TITLE
Recording mode hint

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
@@ -129,6 +129,7 @@ public class Camera1ApiManager implements Camera.PreviewCallback, Camera.FaceDet
       isPortrait = context.getResources().getConfiguration().orientation
           == Configuration.ORIENTATION_PORTRAIT;
       Camera.Parameters parameters = camera.getParameters();
+      parameters.setRecordingHint(true);
       parameters.setPreviewSize(width, height);
       parameters.setPreviewFormat(imageFormat);
       int[] range = adaptFpsRange(fps, parameters.getSupportedPreviewFpsRange());

--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
@@ -129,7 +129,6 @@ public class Camera1ApiManager implements Camera.PreviewCallback, Camera.FaceDet
       isPortrait = context.getResources().getConfiguration().orientation
           == Configuration.ORIENTATION_PORTRAIT;
       Camera.Parameters parameters = camera.getParameters();
-      parameters.setRecordingHint(true);
       parameters.setPreviewSize(width, height);
       parameters.setPreviewFormat(imageFormat);
       int[] range = adaptFpsRange(fps, parameters.getSupportedPreviewFpsRange());
@@ -400,6 +399,22 @@ public class Camera1ApiManager implements Camera.PreviewCallback, Camera.FaceDet
       parameters.setFlashMode(Camera.Parameters.FLASH_MODE_OFF);
       camera.setParameters(parameters);
       lanternEnable = false;
+    }
+  }
+
+  public void enableRecordingHint() {
+    if (camera != null) {
+      Camera.Parameters parameters = camera.getParameters();
+      parameters.setRecordingHint(true);
+      camera.setParameters(parameters);
+    }
+  }
+
+  public void disableRecordingHint() {
+    if (camera != null) {
+      Camera.Parameters parameters = camera.getParameters();
+      parameters.setRecordingHint(false);
+      camera.setParameters(parameters);
     }
   }
 


### PR DESCRIPTION
From the Android docs:
> Sets recording mode hint. This tells the camera that the intent of the application is to record videos, not to take still pictures. 

Makes the camera much smoother on some old and cheap devices.