### PR TITLE
Expose Proguard configs to library consumers

### DIFF
--- a/encoder/build.gradle
+++ b/encoder/build.gradle
@@ -14,7 +14,7 @@ android {
   buildTypes {
     release {
       minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      consumerProguardFiles 'proguard-rules.pro'
     }
   }
 }

--- a/rtmp/build.gradle
+++ b/rtmp/build.gradle
@@ -14,7 +14,6 @@ android {
   buildTypes {
     release {
       minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
     }
   }
 }

--- a/rtplibrary/build.gradle
+++ b/rtplibrary/build.gradle
@@ -14,7 +14,7 @@ android {
   buildTypes {
     release {
       minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      consumerProguardFiles 'proguard-rules.pro'
     }
   }
 }

--- a/rtsp/build.gradle
+++ b/rtsp/build.gradle
@@ -14,7 +14,7 @@ android {
   buildTypes {
     release {
       minifyEnabled false
-      proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+      consumerProguardFiles 'proguard-rules.pro'
     }
   }
 }


### PR DESCRIPTION
When Proguard is run on an app, it's not run on the app as a whole with all of its libraries included. Because of this, `proguardFiles` actually has no effect on an Android library (marked with the `com.android.library` plugin).
`consumerProguardFiles` is what libraries use in order to tell apps using the library about their Proguard configs. None of the libraries in this project have any actual Proguard configs, but if that changes, this will prevent users of the library from having to manually include them in their apps.