### PR TITLE
Remove unnecessary Android manifest attributes and resources

### DIFF
--- a/encoder/src/main/AndroidManifest.xml
+++ b/encoder/src/main/AndroidManifest.xml
@@ -1,12 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pedro.encoder"
-    >
-
-  <application
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-      >
-  </application>
-
-</manifest>
+<manifest package="com.pedro.encoder" />

--- a/encoder/src/main/res/values/strings.xml
+++ b/encoder/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-  <string name="app_name">encoder</string>
-</resources>

--- a/rtmp/src/main/AndroidManifest.xml
+++ b/rtmp/src/main/AndroidManifest.xml
@@ -1,12 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="net.ossrs.rtmp"
-    >
-
-  <application
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-      >
-  </application>
-
-</manifest>
+<manifest package="net.ossrs.rtmp" />

--- a/rtmp/src/main/res/values/strings.xml
+++ b/rtmp/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-  <string name="app_name">library</string>
-</resources>

--- a/rtplibrary/src/main/AndroidManifest.xml
+++ b/rtplibrary/src/main/AndroidManifest.xml
@@ -1,12 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pedro.rtplibrary"
-    >
-
-  <application
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-      >
-  </application>
-
-</manifest>
+<manifest package="com.pedro.rtplibrary" />

--- a/rtplibrary/src/main/res/values/strings.xml
+++ b/rtplibrary/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-  <string name="app_name">builder</string>
-</resources>

--- a/rtsp/src/main/AndroidManifest.xml
+++ b/rtsp/src/main/AndroidManifest.xml
@@ -1,12 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.pedro.rtsp"
-    >
-
-  <application
-      android:allowBackup="true"
-      android:label="@string/app_name"
-      android:supportsRtl="true"
-      >
-  </application>
-
-</manifest>
+<manifest package="com.pedro.rtsp" />

--- a/rtsp/src/main/res/values/strings.xml
+++ b/rtsp/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">Rtsp</string>
-</resources>


### PR DESCRIPTION
Every Android library needs a manifest, but that manifest doesn't actually have to contain any meaningful info besides the package name. In some cases, it can be harmful to provide extra info. For example, each library here specifies `android:supportsRtl="true"`. This is an attribute meant for apps to specify whether or not they support RTL layouts (Arabic, Hebrew, etc). By default, its value is `false`, because most developers don't support or test RTL layouts for their apps. However, apps [merge](https://developer.android.com/studio/build/manifest-merge) their libraries' manifests into their own when building APKs, so specifying `android:supportsRtl` here means that apps that use these libraries will suddenly start being laid out differently in RTL languages, probably without their knowledge. `supportsRtl` and `allowBackup` should generally be up to the app, not the library.

Side note: `rtmp` and `rtsp` don't contain any Android resources, and therefore can (and should) use `java-library` rather than `com.android.library`.