### PR TITLE
Track ByteBuffer offset, to avoid audio crackling.

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/audio/AudioEncoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/audio/AudioEncoder.java
@@ -126,20 +126,20 @@ public class AudioEncoder implements GetMicrophoneData {
    * @param size Min PCM buffer size
    */
   @Override
-  public void inputPCMData(final byte[] buffer, final int size) {
+  public void inputPCMData(final byte[] buffer, final int offset, final int size) {
     if (Build.VERSION.SDK_INT >= 21) {
-      getDataFromEncoderAPI21(buffer, size);
+      getDataFromEncoderAPI21(buffer, offset, size);
     } else {
-      getDataFromEncoder(buffer, size);
+      getDataFromEncoder(buffer, offset, size);
     }
   }
 
   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-  private void getDataFromEncoderAPI21(byte[] data, int size) {
+  private void getDataFromEncoderAPI21(byte[] data, int offset, int size) {
     int inBufferIndex = audioEncoder.dequeueInputBuffer(-1);
     if (inBufferIndex >= 0) {
       ByteBuffer bb = audioEncoder.getInputBuffer(inBufferIndex);
-      bb.put(data, 0, size);
+      bb.put(data, offset, size);
       long pts = System.nanoTime() / 1000 - presentTimeUs;
       audioEncoder.queueInputBuffer(inBufferIndex, 0, size, pts, 0);
     }
@@ -160,7 +160,7 @@ public class AudioEncoder implements GetMicrophoneData {
     }
   }
 
-  private void getDataFromEncoder(byte[] data, int size) {
+  private void getDataFromEncoder(byte[] data, int offset, int size) {
     ByteBuffer[] inputBuffers = audioEncoder.getInputBuffers();
     ByteBuffer[] outputBuffers = audioEncoder.getOutputBuffers();
 

--- a/encoder/src/main/java/com/pedro/encoder/audio/DataTaken.java
+++ b/encoder/src/main/java/com/pedro/encoder/audio/DataTaken.java
@@ -7,10 +7,12 @@ package com.pedro.encoder.audio;
 public class DataTaken {
 
   private byte[] pcmBuffer;
+  private int offset;
   private int size;
 
-  public DataTaken(byte[] pcmBuffer, int size) {
+  public DataTaken(byte[] pcmBuffer, int offset, int size) {
     this.pcmBuffer = pcmBuffer;
+    this.offset = offset;
     this.size = size;
   }
 
@@ -20,6 +22,10 @@ public class DataTaken {
 
   public void setPcmBuffer(byte[] pcmBuffer) {
     this.pcmBuffer = pcmBuffer;
+  }
+
+  public int getOffset() {
+    return offset;
   }
 
   public int getSize() {

--- a/encoder/src/main/java/com/pedro/encoder/input/audio/GetMicrophoneData.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/audio/GetMicrophoneData.java
@@ -6,5 +6,5 @@ package com.pedro.encoder.input.audio;
 
 public interface GetMicrophoneData {
 
-  void inputPCMData(byte[] buffer, int size);
+  void inputPCMData(byte[] buffer, int offset, int size);
 }

--- a/encoder/src/main/java/com/pedro/encoder/input/audio/MicrophoneManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/audio/MicrophoneManager.java
@@ -71,7 +71,7 @@ public class MicrophoneManager {
         while (running && !Thread.interrupted()) {
           DataTaken dataTaken = read();
           if (dataTaken != null) {
-            getMicrophoneData.inputPCMData(dataTaken.getPcmBuffer(), dataTaken.getSize());
+            getMicrophoneData.inputPCMData(dataTaken.getPcmBuffer(), dataTaken.getOffset(), dataTaken.getSize());
           } else {
             running = false;
           }
@@ -113,7 +113,7 @@ public class MicrophoneManager {
     if (size <= 0) {
       return null;
     }
-    return new DataTaken(muted ? pcmBufferMuted : pcmBuffer.array(), size);
+    return new DataTaken(muted ? pcmBufferMuted : pcmBuffer.array(), muted ? 0 : pcmBuffer.arrayOffset(), size);
   }
 
   /**

--- a/encoder/src/main/java/com/pedro/encoder/input/decoder/AudioDecoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/decoder/AudioDecoder.java
@@ -154,10 +154,10 @@ public class AudioDecoder {
             //This buffer is PCM data
             if (muted) {
               outBuffer.get(pcmBufferMuted, 0, pcmBufferMuted.length);
-              getMicrophoneData.inputPCMData(pcmBufferMuted, pcmBufferMuted.length);
+              getMicrophoneData.inputPCMData(pcmBufferMuted, 0, pcmBufferMuted.length);
             } else {
               outBuffer.get(pcmBuffer, 0, outBuffer.remaining());
-              getMicrophoneData.inputPCMData(pcmBuffer, pcmBuffer.length);
+              getMicrophoneData.inputPCMData(pcmBuffer, 0, pcmBuffer.length);
             }
             audioDecoder.releaseOutputBuffer(outIndex, false);
             break;

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
@@ -681,8 +681,8 @@ public abstract class Camera1Base
   }
 
   @Override
-  public void inputPCMData(byte[] buffer, int size) {
-    audioEncoder.inputPCMData(buffer, size);
+  public void inputPCMData(byte[] buffer, int offset, int size) {
+    audioEncoder.inputPCMData(buffer, offset, size);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
@@ -717,8 +717,8 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
   }
 
   @Override
-  public void inputPCMData(byte[] buffer, int size) {
-    audioEncoder.inputPCMData(buffer, size);
+  public void inputPCMData(byte[] buffer, int offset, int size) {
+    audioEncoder.inputPCMData(buffer, offset, size);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
@@ -461,8 +461,8 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
   }
 
   @Override
-  public void inputPCMData(byte[] buffer, int size) {
-    audioEncoder.inputPCMData(buffer, size);
+  public void inputPCMData(byte[] buffer, int offset, int size) {
+    audioEncoder.inputPCMData(buffer, offset, size);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/FromFileBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/FromFileBase.java
@@ -560,8 +560,8 @@ public abstract class FromFileBase
   }
 
   @Override
-  public void inputPCMData(byte[] buffer, int size) {
-    if (audioTrackPlayer != null) audioTrackPlayer.write(buffer, 0, size);
-    audioEncoder.inputPCMData(buffer, size);
+  public void inputPCMData(byte[] buffer, int offset, int size) {
+    if (audioTrackPlayer != null) audioTrackPlayer.write(buffer, offset, size);
+    audioEncoder.inputPCMData(buffer, offset, size);
   }
 }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/OnlyAudioBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/OnlyAudioBase.java
@@ -165,8 +165,8 @@ public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
   }
 
   @Override
-  public void inputPCMData(byte[] buffer, int size) {
-    audioEncoder.inputPCMData(buffer, size);
+  public void inputPCMData(byte[] buffer, int offset, int size) {
+    audioEncoder.inputPCMData(buffer, offset, size);
   }
 
   @Override


### PR DESCRIPTION
In 561ab6a, a byte[] was replaced with a ByteBuffer. I have been trying to use parts of this library, and was getting a lot of audio "crackling" when streaming to YouTube. (Note: I have not tried to use older versions of the library, nor have I tried to do other things with this library than stream to YouTube.)

There were a couple reasons for the crackling, which I think is related to #277, that I was able to fix; the bigger one (I'll talk about the smaller one later today on the issue) was that when I printed out the data being recorded from the audio the buffers all started with 4 bytes of 0 and seemed "shifted".

I tracked the issue down to ByteBuffer not storing its data at the beginning of its underlying backing array (which also might be larger than the requested size): you have to call [.arrayOffset()](https://developer.android.com/reference/java/nio/ByteBuffer.html#arrayOffset()) and then pass that around to all of the consumers of the array. I've crudely hacked that behavior in in this patch.