### PR TITLE
Remove non-existing features for AndroidManifest from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ https://github.com/pedroSG94/rtmp-rtsp-stream-client-java/wiki
 <uses-permission android:name="android.permission.RECORD_AUDIO" />
 <uses-permission android:name="android.permission.CAMERA" />
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-<!--some devices need it-->
-<uses-feature android:name="android.hardware.camera" />
-<uses-feature android:name="android.hardware.camera2.full" />
-<uses-feature android:name="android.hardware.camera2.autofocus" />
+
+<uses-feature android:name="android.hardware.camera" android:required="false" />
+<uses-feature android:name="android.hardware.camera.autofocus" android:required="false"
 ```
 
 ## Compile


### PR DESCRIPTION
"camera2" features are non-existing. Adding them to AndroidManifest caused the app to be incompatible with any device in Play Store.

Resolves #411 