### PR TITLE
fix: demo app service rtp crashes immediately

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,10 @@
   <uses-permission android:name="android.permission.INTERNET"/>
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <uses-permission android:name="android.permission.CAMERA"/>
+
+  <!--needed by background Rtp service to keep service alive-->
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+
   <!--Optional for play store-->
   <uses-feature android:name="android.hardware.camera" android:required="false" />
   <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />


### PR DESCRIPTION
added required permission `FOREGROUND_SERVICE`