### PR TITLE
Add ability to configure AVC Profile and Profile Level

### DIFF
--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
@@ -180,7 +180,7 @@ public abstract class Camera1Base
    * doesn't support any configuration seated or your device hasn't a H264 encoder).
    */
   public boolean prepareVideo(int width, int height, int fps, int bitrate, boolean hardwareRotation,
-      int iFrameInterval, int rotation) {
+      int iFrameInterval, int rotation, int avcProfile, int avcProfileLevel) {
     if (onPreview && width != previewWidth || height != previewHeight) {
       stopPreview();
       onPreview = true;
@@ -188,12 +188,18 @@ public abstract class Camera1Base
     FormatVideoEncoder formatVideoEncoder =
         glInterface == null ? FormatVideoEncoder.YUV420Dynamical : FormatVideoEncoder.SURFACE;
     return videoEncoder.prepareVideoEncoder(width, height, fps, bitrate, rotation, hardwareRotation,
-        iFrameInterval, formatVideoEncoder);
+        iFrameInterval, formatVideoEncoder, avcProfile, avcProfileLevel);
   }
 
   /**
    * backward compatibility reason
    */
+  public boolean prepareVideo(int width, int height, int fps, int bitrate, boolean hardwareRotation,
+                              int iFrameInterval, int rotation) {
+    return prepareVideo(width, height, fps, bitrate, hardwareRotation, iFrameInterval, rotation,
+        -1, -1);
+  }
+
   public boolean prepareVideo(int width, int height, int fps, int bitrate, boolean hardwareRotation,
       int rotation) {
     return prepareVideo(width, height, fps, bitrate, hardwareRotation, 2, rotation);


### PR DESCRIPTION
Some devices such as the Pixel 4 are not automatically selecting the correct profile level which is causing some streaming services to reject the stream.

Using the demo app I tested dumping the results of an ffprobe when broadcasting to an nginx server.  At 640x480 a Pixel 2 correctly reported a profile level of 3.0 whereas the Pixel 4 reported 1.0 which is invalid according to the h.264 spec.  After adding this change and forcing the profile level to 3.0 ffprobe reported the correct profile.