### PR TITLE
Usage of the newest AudioPlaybackCaptureConfiguration (added in Android Q)

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/audio/MicrophoneManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/audio/MicrophoneManager.java
@@ -1,8 +1,10 @@
 package com.pedro.encoder.input.audio;
 
 import android.media.AudioFormat;
+import android.media.AudioPlaybackCaptureConfiguration;
 import android.media.AudioRecord;
 import android.media.MediaRecorder;
+import android.media.projection.MediaProjection;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -46,15 +48,24 @@ public class MicrophoneManager {
   }
 
   /**
-   * Create audio record with params
+   * Create audio record with params and default audio source
    */
   public void createMicrophone(int sampleRate, boolean isStereo, boolean echoCanceler,
       boolean noiseSuppressor) {
+    createMicrophone(MediaRecorder.AudioSource.DEFAULT, sampleRate, isStereo, echoCanceler, noiseSuppressor);
+  }
+
+  /**
+   * Create audio record with params and selected audio source
+   * @param audioSource - the recording source. See {@link MediaRecorder.AudioSource} for the recording source definitions.
+   */
+  public void createMicrophone(int audioSource, int sampleRate, boolean isStereo, boolean echoCanceler,
+                               boolean noiseSuppressor) {
     this.sampleRate = sampleRate;
     if (!isStereo) channel = AudioFormat.CHANNEL_IN_MONO;
     audioRecord =
-        new AudioRecord(MediaRecorder.AudioSource.DEFAULT, sampleRate, channel, audioFormat,
-            getPcmBufferSize());
+            new AudioRecord(audioSource, sampleRate, channel, audioFormat,
+                    getPcmBufferSize());
     audioPostProcessEffect = new AudioPostProcessEffect(audioRecord.getAudioSessionId());
     if (echoCanceler) audioPostProcessEffect.enableEchoCanceler();
     if (noiseSuppressor) audioPostProcessEffect.enableNoiseSuppressor();
@@ -62,6 +73,38 @@ public class MicrophoneManager {
     Log.i(TAG, "Microphone created, " + sampleRate + "hz, " + chl);
     created = true;
   }
+
+  /**
+   * Create audio record with params and AudioPlaybackCaptureConfig used for capturing internal audio
+   * Notice that you should granted {@link android.Manifest.permission#RECORD_AUDIO} before calling this!
+   *
+   * @param config - AudioPlaybackCaptureConfiguration received from {@link android.media.projection.MediaProjection}
+   *
+   * @see AudioPlaybackCaptureConfiguration.Builder#Builder(MediaProjection)
+   * @see "https://developer.android.com/guide/topics/media/playback-capture"
+   * @see "https://medium.com/@debuggingisfun/android-10-audio-capture-77dd8e9070f9"
+   */
+  public void createInternalMicrophone(AudioPlaybackCaptureConfiguration config, int sampleRate, boolean isStereo) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      this.sampleRate = sampleRate;
+      if (!isStereo) channel = AudioFormat.CHANNEL_IN_MONO;
+      audioRecord = new AudioRecord.Builder()
+              .setAudioPlaybackCaptureConfig(config)
+              .setAudioFormat(new AudioFormat.Builder()
+                      .setEncoding(audioFormat)
+                      .setSampleRate(sampleRate)
+                      .setChannelMask(channel)
+                      .build())
+              .setBufferSizeInBytes(getPcmBufferSize())
+              .build();
+
+      audioPostProcessEffect = new AudioPostProcessEffect(audioRecord.getAudioSessionId());
+      String chl = (isStereo) ? "Stereo" : "Mono";
+      Log.i(TAG, "Internal microphone created, " + sampleRate + "hz, " + chl);
+      created = true;
+    } else createMicrophone(sampleRate, isStereo, false, false);
+  }
+
 
   /**
    * Start record and get data

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.base;
 import android.content.Context;
 import android.content.Intent;
 import android.hardware.display.VirtualDisplay;
+import android.media.AudioAttributes;
+import android.media.AudioPlaybackCaptureConfiguration;
 import android.media.MediaCodec;
 import android.media.MediaFormat;
 import android.media.projection.MediaProjection;
@@ -139,6 +141,33 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
   }
 
   /**
+   * Call this method before use @startStream for streaming internal audio only.
+   *
+   * @param bitrate AAC in kb.
+   * @param sampleRate of audio in hz. Can be 8000, 16000, 22500, 32000, 44100.
+   * @param isStereo true if you want Stereo audio (2 audio channels), false if you want Mono audio
+   * (1 audio channel).
+   * @see AudioPlaybackCaptureConfiguration.Builder#Builder(MediaProjection)
+   */
+  @RequiresApi(api = Build.VERSION_CODES.Q)
+  public boolean prepareInternalAudio(int bitrate, int sampleRate, boolean isStereo) {
+    if (mediaProjection == null) {
+      mediaProjection = mediaProjectionManager.getMediaProjection(resultCode, data);
+    }
+
+    AudioPlaybackCaptureConfiguration config = new AudioPlaybackCaptureConfiguration
+            .Builder(mediaProjection)
+            .addMatchingUsage(AudioAttributes.USAGE_MEDIA)
+            .addMatchingUsage(AudioAttributes.USAGE_GAME)
+            .addMatchingUsage(AudioAttributes.USAGE_UNKNOWN)
+            .build();
+    microphoneManager.createInternalMicrophone(config, sampleRate, isStereo);
+    prepareAudioRtp(isStereo, sampleRate);
+    return audioEncoder.prepareAudioEncoder(bitrate, sampleRate, isStereo,
+            microphoneManager.getMaxInputSize());
+  }
+
+  /**
    * Same to call:
    * rotation = 0;
    * if (Portrait) rotation = 90;
@@ -248,7 +277,9 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
     }
     Surface surface =
         (glInterface != null) ? glInterface.getSurface() : videoEncoder.getInputSurface();
-    mediaProjection = mediaProjectionManager.getMediaProjection(resultCode, data);
+    if (mediaProjection == null) {
+      mediaProjection = mediaProjectionManager.getMediaProjection(resultCode, data);
+    }
     virtualDisplay = mediaProjection.createVirtualDisplay("Stream Display", videoEncoder.getWidth(),
         videoEncoder.getHeight(), dpi, 0, surface, null, null);
     microphoneManager.start();


### PR DESCRIPTION
1. AudioPlaybackCaptureConfiguration which was added in Android Q (29) let us capture internal audio without microphone when you're using MediaProjection. So, in DisplayBase instead of prepareAudio() we can call new prepareInternalAudio() method to capture ONLY internal audio.
2. In MicrophoneManager when we call createMicrophone() only MediaRecorder.AudioSource.DEFAULT was used by default. But, e.g., MediaRecorder.AudioSource.CAMCODER records sound with better quality and without extraneous noise. So, let the user choose the audio source.