### PR TITLE
fixed problem in Audio encoder when streaming rtmp from file

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/decoder/AudioDecoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/decoder/AudioDecoder.java
@@ -29,8 +29,8 @@ public class AudioDecoder {
   private String mime = "";
   private int sampleRate;
   private boolean isStereo;
-  private int channels = 2;
-  private int size = 4096;
+  private int channels = 1;
+  private int size = 2048;
   private byte[] pcmBuffer = new byte[size];
   private byte[] pcmBufferMuted = new byte[11];
   private static boolean loopMode = false;
@@ -64,7 +64,7 @@ public class AudioDecoder {
       isStereo = channels >= 2;
       sampleRate = audioFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE);
       duration = audioFormat.getLong(MediaFormat.KEY_DURATION);
-      if (channels > 2) {
+      if (channels >= 2) {
         pcmBuffer = new byte[2048 * channels];
       }
       return true;


### PR DESCRIPTION
Hi :)
I found a problem with `AudioDecoder.java` when I was trying to stream rtmp from file and the input file has mono sound. 
The output audio from the library was corrupted. The bug is the size of `pcmBuffer` variable which is set up for stereo audio and it's not reinitialized when `channels` variable is set to 1 in `initExtractor` function. Please take a look :) 