### PR TITLE
Added ability to pause and resume stream

### DIFF
--- a/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtmpActivity.java
@@ -107,6 +107,8 @@ public class OpenGlRtmpActivity extends AppCompatActivity
     bRecord.setOnClickListener(this);
     Button switchCamera = findViewById(R.id.switch_camera);
     switchCamera.setOnClickListener(this);
+    findViewById(R.id.b_pause_stream).setOnClickListener(this);
+    findViewById(R.id.b_resume_stream).setOnClickListener(this);
     etUrl = findViewById(R.id.et_rtp_url);
     etUrl.setHint(R.string.hint_rtmp);
     rtmpCamera1 = new RtmpCamera1(openGlView, this);
@@ -405,6 +407,16 @@ public class OpenGlRtmpActivity extends AppCompatActivity
           rtmpCamera1.switchCamera();
         } catch (CameraOpenException e) {
           Toast.makeText(this, e.getMessage(), Toast.LENGTH_SHORT).show();
+        }
+        break;
+      case R.id.b_pause_stream:
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+          rtmpCamera1.pauseStream();
+        }
+        break;
+      case R.id.b_resume_stream:
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+          rtmpCamera1.resumeStream();
         }
         break;
       case R.id.b_record:

--- a/app/src/main/res/layout/activity_open_gl.xml
+++ b/app/src/main/res/layout/activity_open_gl.xml
@@ -31,6 +31,30 @@
   <LinearLayout
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
+      android:layout_above="@+id/bottom_buttons"
+      android:gravity="center"
+      android:orientation="horizontal">
+
+    <Button
+        android:id="@+id/b_pause_stream"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="5dp"
+        android:text="@string/pause_stream" />
+
+    <Button
+        android:id="@+id/b_resume_stream"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginRight="5dp"
+        android:text="@string/resume_stream" />
+
+  </LinearLayout>
+
+  <LinearLayout
+      android:id="@+id/bottom_buttons"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
       android:orientation="horizontal"
       android:layout_alignParentBottom="true"
       android:layout_margin="20dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
   <string name="select_file">Select file</string>
   <string name="start_record">Start record</string>
   <string name="stop_record">Stop record</string>
+  <string name="pause_stream">Pause stream</string>
+  <string name="resume_stream">Resume stream</string>
   <string name="resync_file">ReSync file</string>
   <!--menu-->
   <string name="microphone">Microphone</string>

--- a/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
@@ -176,6 +176,20 @@ public class VideoEncoder extends BaseEncoder implements GetCameraData {
     Log.i(TAG, "started");
   }
 
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void pause() {
+    Bundle params = new Bundle();
+    params.putInt(MediaCodec.PARAMETER_KEY_SUSPEND, 1);
+    codec.setParameters(params);
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void resume() {
+    Bundle params = new Bundle();
+    params.putInt(MediaCodec.PARAMETER_KEY_SUSPEND, 0);
+    codec.setParameters(params);
+  }
+
   @Override
   protected void stopImp() {
     if (handlerThread != null) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
@@ -459,6 +459,40 @@ public abstract class Camera1Base
     onPreview = true;
   }
 
+  /**
+   * Pauses only video part of a stream keeping preview on.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void pauseStreamVideo() {
+    videoEncoder.pause();
+  }
+
+  /**
+   * Resumes video part of a stream.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void resumeStreamVideo() {
+    videoEncoder.resume();
+  }
+
+  /**
+   * Pauses both video and audio part of a stream keeping preview on.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void pauseStream() {
+    pauseStreamVideo();
+    disableAudio();
+  }
+
+  /**
+   * Resumes both video and audio part of a stream.
+   */
+  @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+  public void resumeStream() {
+    resumeStreamVideo();
+    enableAudio();
+  }
+
   private void startEncoders() {
     videoEncoder.start();
     audioEncoder.start();

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
@@ -432,6 +432,36 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
     onPreview = true;
   }
 
+  /**
+   * Pauses only video part of a stream keeping preview on.
+   */
+  public void pauseStreamVideo() {
+    videoEncoder.pause();
+  }
+
+  /**
+   * Resumes video part of a stream.
+   */
+  public void resumeStreamVideo() {
+    videoEncoder.resume();
+  }
+
+  /**
+   * Pauses both video and audio part of a stream keeping preview on.
+   */
+  public void pauseStream() {
+    pauseStreamVideo();
+    disableAudio();
+  }
+
+  /**
+   * Resumes both video and audio part of a stream.
+   */
+  public void resumeStream() {
+    resumeStreamVideo();
+    enableAudio();
+  }
+
   private void startEncoders() {
     videoEncoder.start();
     audioEncoder.start();


### PR DESCRIPTION
Hi @pedroSG94 
I need an option to pause and resume the stream. Here is my implementation of it.
I've checked it on two devices (Android 8 and 10) and it seems to work well.

As you can see, I pause video encoder and mute microphone. I've tried pausing audio encoder but it didn't work. Maybe it doesn't work because audio has no surface input like mentioned in this comment https://developer.android.com/reference/android/media/MediaCodec#PARAMETER_KEY_SUSPEND
`This parameter really only makes sense to use with an encoder in "surface-input" mode`

I'm not 100% sure how reliable is this flag so I was also thinking to not render video in OpenGL like this:
`ManagerRenderer::64`
```
  public void drawScreen(int width, int height, boolean keepAspectRatio, int mode, int rotation,
      boolean isPreview) {
    if (isPreview || !disableStreamVideo) 
        screenRender.draw(width, height, keepAspectRatio, mode, rotation, isPreview);
  }
```
What do you think about it?
