### PR TITLE
Resetting frames after disconnect callback

### DIFF
--- a/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
@@ -196,15 +196,16 @@ public class SrsFlvMuxer {
     mVideoSequenceHeader = null;
     mAudioSequenceHeader = null;
 
+    if (connectChecker != null) {
+      reTries = 0;
+      connectChecker.onDisconnectRtmp();
+    }
+
     resetSentAudioFrames();
     resetSentVideoFrames();
     resetDroppedAudioFrames();
     resetDroppedVideoFrames();
 
-    if (connectChecker != null) {
-      reTries = 0;
-      connectChecker.onDisconnectRtmp();
-    }
     Log.i(TAG, "worker: disconnect ok.");
   }
 


### PR DESCRIPTION
Hi @pedroSG94 
Small PR. I need to log dropped and sent frames to Analytics. Currently, it's hard to grab dropped frames after a stream has been disconnected as they are cleared right before Disconnected callback.
I just moved clearing frames after the callback.