### PR TITLE
 screen is not visible when entering the background during streaming

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.java
@@ -114,7 +114,7 @@ public class Camera2ApiManager extends CameraDevice.StateCallback {
       final List<Surface> listSurfaces = new ArrayList<>();
       Surface preview = addPreviewSurface();
       if (preview != null) listSurfaces.add(preview);
-      if (surfaceEncoder != null) listSurfaces.add(surfaceEncoder);
+      if (surfaceEncoder != preview && surfaceEncoder != null) listSurfaces.add(surfaceEncoder);
 
       cameraDevice.createCaptureSession(listSurfaces, new CameraCaptureSession.StateCallback() {
         @Override


### PR DESCRIPTION
Fixed a bug where the surfaceview was not visible when entering background during streaming or recoding