### PR TITLE
Catch all exception types during encoder creation

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/audio/AudioEncoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/audio/AudioEncoder.java
@@ -66,7 +66,7 @@ public class AudioEncoder extends BaseEncoder implements GetMicrophoneData {
       running = false;
       Log.i(TAG, "prepared");
       return true;
-    } catch (IOException | IllegalStateException e) {
+    } catch (Exception e) {
       Log.e(TAG, "Create AudioEncoder failed.", e);
       this.stop();
       return false;

--- a/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
@@ -137,7 +137,7 @@ public class VideoEncoder extends BaseEncoder implements GetCameraData {
       }
       Log.i(TAG, "prepared");
       return true;
-    } catch (IOException | IllegalStateException e) {
+    } catch (Exception e) {
       Log.e(TAG, "Create VideoEncoder failed.", e);
       this.stop();
       return false;


### PR DESCRIPTION
On some devices I see `IllegalArgument` exception sometimes thrown when the encoder is unhappy with unsupported configuration.

But we should probably catch all exceptions here. So I made this catch all exception types.