### PR TITLE
Increased connection timeout for authorized connections

### DIFF
--- a/rtmp/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
+++ b/rtmp/src/main/java/com/github/faucamp/simplertmp/io/RtmpConnection.java
@@ -196,7 +196,7 @@ public class RtmpConnection implements RtmpPublisher {
     sendConnect("");
     synchronized (connectingLock) {
       try {
-        connectingLock.wait(5000);
+        connectingLock.wait(getConnectionTimeoutMs());
       } catch (InterruptedException ex) {
         // do nothing
       }
@@ -753,6 +753,16 @@ public class RtmpConnection implements RtmpPublisher {
       default:
         Log.e(TAG, "handleRxInvoke(): Unknown/unhandled server invoke: " + invoke);
         break;
+    }
+  }
+
+  private long getConnectionTimeoutMs() {
+    final long defaultTimeoutMs = 5_000;
+    if (user != null && password != null) {
+      // Authorized connection may take about 3 times longer than a regular, that's why the timeout is longer.
+      return 3 * defaultTimeoutMs;
+    } else {
+      return defaultTimeoutMs;
     }
   }
 


### PR DESCRIPTION
Hi @pedroSG94 
I'm migrating to the llnw authorization that you added (thanks a lot for that). I had a problem that it didn't work for me.
It turned out that the connection timeout of 5 seconds is not enough and it stops the stream during the connection.
I've noticed that there is a call `connectingLock.wait(5000)` in the `RtmpConnection.rtmpConnect()` method.
But this is called at the beginning of the whole connection process and not for each `connect` command.
When you use authorization everything is sent three times, like the handshake, connect, etc. That's why 5 seconds may not be enough to connect. In my case, it was usually ~7 seconds but it depends on the server. For some other streams I used, it took only 2 seconds. So just for safety, I set 15 seconds timeout for authorized streams. 
I thought to let the user define the timeout as well but it would require changing too many classes :D 