### PR TITLE
Added backup url support

### DIFF
--- a/app/src/main/java/com/pedro/rtpstreamer/backgroundexample/RtpService.kt
+++ b/app/src/main/java/com/pedro/rtpstreamer/backgroundexample/RtpService.kt
@@ -131,6 +131,9 @@ class RtpService : Service() {
       override fun onAuthSuccessRtp() {
         showNotification("Stream auth success")
       }
+
+      override fun onConnectionStarted(rtmpUrl: String) {
+      }
     }
 
     private fun showNotification(text: String) {

--- a/app/src/main/java/com/pedro/rtpstreamer/customexample/RtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/customexample/RtmpActivity.java
@@ -304,6 +304,10 @@ public class RtmpActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/customexample/RtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/customexample/RtspActivity.java
@@ -32,6 +32,9 @@ import com.pedro.rtplibrary.rtsp.RtspCamera1;
 import com.pedro.rtpstreamer.R;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -454,5 +457,9 @@ public class RtspActivity extends AppCompatActivity
       }
     }
     return true;
+  }
+
+  @Override
+  public void onConnectionStarted(@NotNull String rtmpUrl) {
   }
 }

--- a/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtmpActivity.java
@@ -72,7 +72,7 @@ public class ExampleRtmpActivity extends AppCompatActivity
     runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        if (rtmpCamera1.reTry(5000, reason)) {
+        if (rtmpCamera1.reTry(5000, reason, null)) {
           Toast.makeText(ExampleRtmpActivity.this, "Retry", Toast.LENGTH_SHORT)
               .show();
         } else {

--- a/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtmpActivity.java
@@ -58,6 +58,10 @@ public class ExampleRtmpActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtspActivity.java
@@ -15,6 +15,9 @@ import com.pedro.encoder.input.video.CameraOpenException;
 import com.pedro.rtplibrary.rtsp.RtspCamera1;
 import com.pedro.rtpstreamer.R;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -219,5 +222,9 @@ public class ExampleRtspActivity extends AppCompatActivity
       button.setText(getResources().getString(R.string.start_button));
     }
     rtspCamera1.stopPreview();
+  }
+
+  @Override
+  public void onConnectionStarted(@NotNull String rtmpUrl) {
   }
 }

--- a/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/defaultexample/ExampleRtspActivity.java
@@ -72,7 +72,7 @@ public class ExampleRtspActivity extends AppCompatActivity
     runOnUiThread(new Runnable() {
       @Override
       public void run() {
-        if (rtspCamera1.reTry(5000, reason)) {
+        if (rtspCamera1.reTry(5000, reason, null)) {
           Toast.makeText(ExampleRtspActivity.this, "Retry", Toast.LENGTH_SHORT)
               .show();
         } else {

--- a/app/src/main/java/com/pedro/rtpstreamer/displayexample/DisplayActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/displayexample/DisplayActivity.java
@@ -77,6 +77,10 @@ public class DisplayActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/displayexample/DisplayService.kt
+++ b/app/src/main/java/com/pedro/rtpstreamer/displayexample/DisplayService.kt
@@ -106,6 +106,9 @@ class DisplayService : Service() {
     }
 
     private val connectCheckerRtp = object : ConnectCheckerRtp {
+      override fun onConnectionStarted(rtmpUrl: String) {
+      }
+
       override fun onConnectionSuccessRtp() {
         showNotification("Stream started")
         Log.e(TAG, "RTP service destroy")

--- a/app/src/main/java/com/pedro/rtpstreamer/filestreamexample/RtmpFromFileActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/filestreamexample/RtmpFromFileActivity.java
@@ -85,6 +85,10 @@ public class RtmpFromFileActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/filestreamexample/RtspFromFileActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/filestreamexample/RtspFromFileActivity.java
@@ -21,6 +21,9 @@ import com.pedro.rtplibrary.rtsp.RtspFromFile;
 import com.pedro.rtpstreamer.R;
 import com.pedro.rtpstreamer.utils.PathUtils;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -314,5 +317,9 @@ public class RtspFromFileActivity extends AppCompatActivity
   public void onStopTrackingTouch(SeekBar seekBar) {
     if (rtspFromFile.isStreaming()) rtspFromFile.moveTo(seekBar.getProgress());
     touching = false;
+  }
+
+  @Override
+  public void onConnectionStarted(@NotNull String rtmpUrl) {
   }
 }

--- a/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtmpActivity.java
@@ -331,6 +331,10 @@ public class OpenGlRtmpActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/openglexample/OpenGlRtspActivity.java
@@ -78,6 +78,8 @@ import java.util.Locale;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * More documentation see:
  * {@link com.pedro.rtplibrary.base.Camera1Base}
@@ -496,5 +498,9 @@ public class OpenGlRtspActivity extends AppCompatActivity
       return true;
     }
     return false;
+  }
+
+  @Override
+  public void onConnectionStarted(@NotNull String rtmpUrl) {
   }
 }

--- a/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtmpActivity.java
@@ -76,7 +76,7 @@ public class SurfaceModeRtmpActivity extends AppCompatActivity
       @Override
       public void run() {
         //Wait 5s and retry connect stream
-        if (rtmpCamera2.reTry(5000, reason)) {
+        if (rtmpCamera2.reTry(5000, reason, null)) {
           Toast.makeText(SurfaceModeRtmpActivity.this, "Retry", Toast.LENGTH_SHORT)
               .show();
         } else {

--- a/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtmpActivity.java
@@ -60,6 +60,10 @@ public class SurfaceModeRtmpActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtspActivity.java
@@ -17,6 +17,9 @@ import com.pedro.encoder.input.video.CameraOpenException;
 import com.pedro.rtplibrary.rtsp.RtspCamera2;
 import com.pedro.rtpstreamer.R;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -92,6 +95,10 @@ public class SurfaceModeRtspActivity extends AppCompatActivity
   @Override
   public void onNewBitrateRtsp(long bitrate) {
 
+  }
+
+  @Override
+  public void onConnectionStarted(@NotNull String rtmpUrl) {
   }
 
   @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/surfacemodeexample/SurfaceModeRtspActivity.java
@@ -77,7 +77,7 @@ public class SurfaceModeRtspActivity extends AppCompatActivity
       @Override
       public void run() {
         //Wait 5s and retry connect stream
-        if (rtspCamera2.reTry(5000, reason)) {
+        if (rtspCamera2.reTry(5000, reason, null)) {
           Toast.makeText(SurfaceModeRtspActivity.this, "Retry", Toast.LENGTH_SHORT)
               .show();
         } else {

--- a/app/src/main/java/com/pedro/rtpstreamer/texturemodeexample/TextureModeRtmpActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/texturemodeexample/TextureModeRtmpActivity.java
@@ -61,6 +61,10 @@ public class TextureModeRtmpActivity extends AppCompatActivity
   }
 
   @Override
+  public void onConnectionStarted(String rtmpUrl) {
+  }
+
+  @Override
   public void onConnectionSuccessRtmp() {
     runOnUiThread(new Runnable() {
       @Override

--- a/app/src/main/java/com/pedro/rtpstreamer/texturemodeexample/TextureModeRtspActivity.java
+++ b/app/src/main/java/com/pedro/rtpstreamer/texturemodeexample/TextureModeRtspActivity.java
@@ -17,6 +17,9 @@ import com.pedro.rtpstreamer.R;
 import com.pedro.rtplibrary.rtsp.RtspCamera2;
 import com.pedro.rtplibrary.view.AutoFitTextureView;
 import com.pedro.rtsp.utils.ConnectCheckerRtsp;
+
+import org.jetbrains.annotations.NotNull;
+
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
@@ -222,5 +225,9 @@ public class TextureModeRtspActivity extends AppCompatActivity
   @Override
   public void onPointerCaptureChanged(boolean hasCapture) {
 
+  }
+
+  @Override
+  public void onConnectionStarted(@NotNull String rtmpUrl) {
   }
 }

--- a/rtmp/src/main/java/net/ossrs/rtmp/ConnectCheckerRtmp.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/ConnectCheckerRtmp.java
@@ -5,6 +5,8 @@ package net.ossrs.rtmp;
  */
 public interface ConnectCheckerRtmp {
 
+  void onConnectionStarted(String rtmpUrl);
+
   void onConnectionSuccessRtmp();
 
   void onConnectionFailedRtmp(String reason);

--- a/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
@@ -239,6 +239,7 @@ public class SrsFlvMuxer {
 
   private boolean connect(String url) {
     this.url = url;
+    connectCheckerRtmp.onConnectionStarted(url);
     if (!connected) {
       Log.i(TAG, String.format("worker: connecting to RTMP server by url=%s\n", url));
       if (publisher.connect(url)) {

--- a/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
+++ b/rtmp/src/main/java/net/ossrs/rtmp/SrsFlvMuxer.java
@@ -224,13 +224,14 @@ public class SrsFlvMuxer {
     return validReason && reTries > 0;
   }
 
-  public void reConnect(final long delay) {
+  public void reConnect(final long delay, final String backupUrl) {
     reTries--;
     stop(null);
     runnable = new Runnable() {
       @Override
       public void run() {
-        start(url, true);
+        String reconnectUrl = backupUrl != null ? backupUrl : url;
+        start(reconnectUrl, true);
       }
     };
     handler.postDelayed(runnable, delay);
@@ -275,7 +276,7 @@ public class SrsFlvMuxer {
   /**
    * start to the remote SRS for remux.
    */
-  public void start(final String rtmpUrl, final boolean isRetry) {
+  private void start(final String rtmpUrl, final boolean isRetry) {
     if (!isRetry) doingRetry = true;
     startTs = System.nanoTime() / 1000;
     worker = new Thread(new Runnable() {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
@@ -640,32 +640,41 @@ public abstract class Camera1Base
     }
   }
 
-  public boolean reTry(long delay, String reason) {
+  /**
+   * Retries to connect with the given delay. You can pass an optional backupUrl
+   * if you'd like to connect to your backup server instead of the original one.
+   * Given backupUrl replaces the original one.
+   */
+  public boolean reTry(long delay, String reason, @Nullable String backupUrl) {
     boolean result = shouldRetry(reason);
     if (result) {
-      reTry(delay);
+      reTry(delay, backupUrl);
     }
     return result;
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public void reTry(long delay) {
+    reTry(delay, null);
+  }
+
+  private void reTry(long delay, @Nullable String backupUrl) {
     resetVideoEncoder(true);
-    reConnect(delay);
+    reConnect(delay, backupUrl);
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public abstract boolean shouldRetry(String reason);
 
   public abstract void setReTries(int reTries);
 
-  protected abstract void reConnect(long delay);
+  protected abstract void reConnect(long delay, @Nullable String backupUrl);
 
   //cache control
   public abstract boolean hasCongestion();

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
@@ -645,32 +645,41 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
     }
   }
 
-  public boolean reTry(long delay, String reason) {
+  /**
+   * Retries to connect with the given delay. You can pass an optional backupUrl
+   * if you'd like to connect to your backup server instead of the original one.
+   * Given backupUrl replaces the original one.
+   */
+  public boolean reTry(long delay, String reason, @Nullable String backupUrl) {
     boolean result = shouldRetry(reason);
     if (result) {
-      reTry(delay);
+      reTry(delay, backupUrl);
     }
     return result;
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public void reTry(long delay) {
+    reTry(delay, null);
+  }
+
+  private void reTry(long delay, @Nullable String backupUrl) {
     resetVideoEncoder(true);
-    reConnect(delay);
+    reConnect(delay, backupUrl);
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public abstract boolean shouldRetry(String reason);
 
   public abstract void setReTries(int reTries);
 
-  protected abstract void reConnect(long delay);
+  protected abstract void reConnect(long delay, @Nullable String backupUrl);
 
   //cache control
   public abstract boolean hasCongestion();

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
@@ -434,32 +434,41 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
     }
   }
 
-  public boolean reTry(long delay, String reason) {
+  /**
+   * Retries to connect with the given delay. You can pass an optional backupUrl
+   * if you'd like to connect to your backup server instead of the original one.
+   * Given backupUrl replaces the original one.
+   */
+  public boolean reTry(long delay, String reason, @Nullable String backupUrl) {
     boolean result = shouldRetry(reason);
     if (result) {
-      reTry(delay);
+      reTry(delay, backupUrl);
     }
     return result;
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public void reTry(long delay) {
+    reTry(delay, null);
+  }
+
+  private void reTry(long delay, @Nullable String backupUrl) {
     resetVideoEncoder(true);
-    reConnect(delay);
+    reConnect(delay, backupUrl);
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public abstract boolean shouldRetry(String reason);
 
   public abstract void setReTries(int reTries);
 
-  protected abstract void reConnect(long delay);
+  protected abstract void reConnect(long delay, @Nullable String backupUrl);
 
   //cache control
   public abstract boolean hasCongestion();

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/FromFileBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/FromFileBase.java
@@ -389,10 +389,15 @@ public abstract class FromFileBase
 
   protected abstract void stopStreamRtp();
 
-  public boolean reTry(long delay, String reason) {
+  /**
+   * Retries to connect with the given delay. You can pass an optional backupUrl
+   * if you'd like to connect to your backup server instead of the original one.
+   * Given backupUrl replaces the original one.
+   */
+  public boolean reTry(long delay, String reason, @Nullable String backupUrl) {
     boolean result = shouldRetry(reason);
     if (result) {
-      reTry(delay);
+      reTry(delay, backupUrl);
     }
     return result;
   }
@@ -402,8 +407,12 @@ public abstract class FromFileBase
    */
   @Deprecated
   public void reTry(long delay) {
+    reTry(delay, null);
+  }
+
+  private void reTry(long delay, @Nullable String backupUrl) {
     if (videoEnabled) resetVideoEncoder(true);
-    reConnect(delay);
+    reConnect(delay, backupUrl);
   }
 
   /**
@@ -414,7 +423,7 @@ public abstract class FromFileBase
 
   public abstract void setReTries(int reTries);
 
-  protected abstract void reConnect(long delay);
+  protected abstract void reConnect(long delay, @Nullable String backupUrl);
 
   //cache control
   public abstract boolean hasCongestion();

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/OnlyAudioBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/OnlyAudioBase.java
@@ -230,31 +230,35 @@ public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
     return recordController.getStatus();
   }
 
-  public boolean reTry(long delay, String reason) {
+  public boolean reTry(long delay, String reason, @Nullable String backupUrl) {
     boolean result = shouldRetry(reason);
     if (result) {
-      reTry(delay);
+      reTry(delay, backupUrl);
     }
     return result;
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public void reTry(long delay) {
-    reConnect(delay);
+    reTry(delay, null);
+  }
+
+  private void reTry(long delay, @Nullable String backupUrl) {
+    reConnect(delay, backupUrl);
   }
 
   /**
-   * Replace with reTry(long delay, String reason);
+   * Replace with reTry(long delay, String reason, String backupUrl);
    */
   @Deprecated
   public abstract boolean shouldRetry(String reason);
 
   public abstract void setReTries(int reTries);
 
-  protected abstract void reConnect(long delay);
+  protected abstract void reConnect(long delay, @Nullable String backupUrl);
 
   //cache control
   public abstract boolean hasCongestion();

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtmp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import android.view.SurfaceView;
 import android.view.TextureView;
@@ -159,8 +161,8 @@ public class RtmpCamera1 extends Camera1Base {
   }
 
   @Override
-  public void reConnect(long delay) {
-    srsFlvMuxer.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    srsFlvMuxer.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtmp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import android.view.SurfaceView;
 import android.view.TextureView;
@@ -171,8 +173,8 @@ public class RtmpCamera2 extends Camera2Base {
   }
 
   @Override
-  public void reConnect(long delay) {
-    srsFlvMuxer.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    srsFlvMuxer.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpDisplay.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpDisplay.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtmp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 import com.pedro.rtplibrary.base.DisplayBase;
@@ -135,8 +137,8 @@ public class RtmpDisplay extends DisplayBase {
   }
 
   @Override
-  public void reConnect(long delay) {
-    srsFlvMuxer.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    srsFlvMuxer.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpFromFile.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpFromFile.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtmp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 import com.pedro.encoder.input.decoder.AudioDecoderInterface;
@@ -158,8 +160,8 @@ public class RtmpFromFile extends FromFileBase {
   }
 
   @Override
-  public void reConnect(long delay) {
-    srsFlvMuxer.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    srsFlvMuxer.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpOnlyAudio.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpOnlyAudio.java
@@ -1,6 +1,9 @@
 package com.pedro.rtplibrary.rtmp;
 
 import android.media.MediaCodec;
+
+import androidx.annotation.Nullable;
+
 import com.pedro.rtplibrary.base.OnlyAudioBase;
 import java.nio.ByteBuffer;
 import net.ossrs.rtmp.ConnectCheckerRtmp;
@@ -114,8 +117,8 @@ public class RtmpOnlyAudio extends OnlyAudioBase {
   }
 
   @Override
-  public void reConnect(long delay) {
-    srsFlvMuxer.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    srsFlvMuxer.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera1.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera1.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtsp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import android.view.SurfaceView;
 import android.view.TextureView;
@@ -152,8 +154,8 @@ public class RtspCamera1 extends Camera1Base {
   }
 
   @Override
-  public void reConnect(long delay) {
-    rtspClient.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    rtspClient.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtsp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import android.view.SurfaceView;
 import android.view.TextureView;
@@ -163,8 +165,8 @@ public class RtspCamera2 extends Camera2Base {
   }
 
   @Override
-  public void reConnect(long delay) {
-    rtspClient.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    rtspClient.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspDisplay.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspDisplay.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtsp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import com.pedro.encoder.utils.CodecUtil;
 import com.pedro.rtplibrary.base.DisplayBase;
@@ -125,8 +127,8 @@ public class RtspDisplay extends DisplayBase {
   }
 
   @Override
-  public void reConnect(long delay) {
-    rtspClient.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    rtspClient.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspFromFile.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspFromFile.java
@@ -3,6 +3,8 @@ package com.pedro.rtplibrary.rtsp;
 import android.content.Context;
 import android.media.MediaCodec;
 import android.os.Build;
+
+import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import com.pedro.encoder.input.decoder.AudioDecoderInterface;
 import com.pedro.encoder.input.decoder.VideoDecoderInterface;
@@ -149,8 +151,8 @@ public class RtspFromFile extends FromFileBase {
   }
 
   @Override
-  public void reConnect(long delay) {
-    rtspClient.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    rtspClient.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspOnlyAudio.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspOnlyAudio.java
@@ -1,6 +1,9 @@
 package com.pedro.rtplibrary.rtsp;
 
 import android.media.MediaCodec;
+
+import androidx.annotation.Nullable;
+
 import com.pedro.rtplibrary.base.OnlyAudioBase;
 import com.pedro.rtsp.rtsp.Protocol;
 import com.pedro.rtsp.rtsp.RtspClient;
@@ -114,8 +117,8 @@ public class RtspOnlyAudio extends OnlyAudioBase {
   }
 
   @Override
-  public void reConnect(long delay) {
-    rtspClient.reConnect(delay);
+  public void reConnect(long delay, @Nullable String backupUrl) {
+    rtspClient.reConnect(delay, backupUrl);
   }
 
   @Override

--- a/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
+++ b/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
@@ -117,6 +117,7 @@ open class RtspClient(private val connectCheckerRtsp: ConnectCheckerRtsp) {
     }
     if (!isStreaming || isRetry) {
       this.url = url
+      connectCheckerRtsp.onConnectionStarted(url)
       val rtspMatcher = rtspUrlPattern.matcher(url)
       if (rtspMatcher.matches()) {
         tlsEnabled = (rtspMatcher.group(0) ?: "").startsWith("rtsps")

--- a/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
+++ b/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
@@ -139,7 +139,7 @@ open class RtspClient(private val connectCheckerRtsp: ConnectCheckerRtsp) {
           try {
             commandsManager.setUrl(host, port, path)
             rtspSender.setSocketsInfo(commandsManager.protocol,
-                commandsManager.videoClientPorts, commandsManager.audioClientPorts)
+              commandsManager.videoClientPorts, commandsManager.audioClientPorts)
             rtspSender.setAudioInfo(commandsManager.sampleRate)
             if (!commandsManager.isOnlyAudio) {
               if (commandsManager.sps == null && commandsManager.pps == null) {
@@ -343,12 +343,13 @@ open class RtspClient(private val connectCheckerRtsp: ConnectCheckerRtsp) {
     return rtspSender.hasCongestion()
   }
 
-  fun reConnect(delay: Long) {
+  fun reConnect(delay: Long, backupUrl: String?) {
     reTries--
     disconnect(false)
     runnable = Runnable {
       Log.e("Pedro", "connect")
-      connect(url, true)
+      val reconnectUrl = backupUrl ?: url
+      connect(reconnectUrl, true)
     }
     runnable?.let { handler.postDelayed(it, delay) }
   }

--- a/rtsp/src/main/java/com/pedro/rtsp/utils/ConnectCheckerRtsp.kt
+++ b/rtsp/src/main/java/com/pedro/rtsp/utils/ConnectCheckerRtsp.kt
@@ -4,6 +4,7 @@ package com.pedro.rtsp.utils
  * Created by pedro on 20/02/17.
  */
 interface ConnectCheckerRtsp {
+  fun onConnectionStarted(rtmpUrl: String)
   fun onConnectionSuccessRtsp()
   fun onConnectionFailedRtsp(reason: String)
   fun onNewBitrateRtsp(bitrate: Long)


### PR DESCRIPTION
Hi @pedroSG94 
I added support for the backup URL. We started using this in our app.
The behavior is that when connection fails and retry is triggered then the backup URL is being used, for the next retry if the backup URL fails, the original URL is being used, and so on.

I moved the assignment of `SrsFlvMuxer.url` to the `start()` method so it's not overridden by the `backupUrl` in the `connect()` method.
I implemented it only for RTMP. If the implementation is fine I can try to do this for RTSP as well, however, I'm not sure if I can easily test it.