### PR TITLE
Ignore SPS/PPS on IDR frames

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
@@ -107,6 +107,7 @@ public class VideoEncoder extends BaseEncoder implements GetCameraData {
       Log.i(TAG, "Prepare video info: " + this.formatVideoEncoder.name() + ", " + resolution);
       videoFormat.setInteger(MediaFormat.KEY_COLOR_FORMAT,
           this.formatVideoEncoder.getFormatCodec());
+      videoFormat.setInteger(MediaFormat.KEY_PREPEND_HEADER_TO_SYNC_FRAMES, 0);
       videoFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 0);
       videoFormat.setInteger(MediaFormat.KEY_BIT_RATE, bitRate);
       videoFormat.setInteger(MediaFormat.KEY_FRAME_RATE, fps);


### PR DESCRIPTION
Some encoders, like `c2.qti.avc.encoder` and `OMX.qcom.video.encoder.avc`, sometimes have the default value of `prepend-sps-pps-to-idr-frames` set to 1 internally, which makes the video not to work on some servers, such as nginx-rtmp.
The default value according to [Android documentation](https://developer.android.com/reference/android/media/MediaFormat#KEY_PREPEND_HEADER_TO_SYNC_FRAMES) is supposed to be 0, but I guess some encoders have it internally different.

Before this change, the video wasn't showing on VLC and if running ffmpeg it was showing many times the following:
```
[h264 @ 0x7fbe1c8e0000] non-existing PPS 0 referenced
[h264 @ 0x7fbe1c8e0000] decode_slice_header error
[h264 @ 0x7fbe1c8e0000] no frame!
```

Fixes #874 and #381