### PR TITLE
Fixed bytes to hex function

### DIFF
--- a/rtmp/build.gradle
+++ b/rtmp/build.gradle
@@ -21,4 +21,6 @@ android {
 
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+  testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/rtmp/src/main/java/com/pedro/rtmp/utils/AuthUtil.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/utils/AuthUtil.kt
@@ -128,11 +128,11 @@ object AuthUtil {
     return ""
   }
 
-  private fun bytesToHex(bytes: ByteArray): String {
+  fun bytesToHex(bytes: ByteArray): String {
     val hexChars = CharArray(bytes.size * 2)
     var v: Int
     for (j in bytes.indices) {
-      v = (bytes[j] and 0xFF.toByte()).toInt()
+      v = bytes[j].toInt() and 0xFF
       hexChars[j * 2] = hexArray[v ushr 4]
       hexChars[j * 2 + 1] = hexArray[v and 0x0F]
     }

--- a/rtmp/src/test/java/com/pedro/rtmp/utils/AuthUtilTest.kt
+++ b/rtmp/src/test/java/com/pedro/rtmp/utils/AuthUtilTest.kt
@@ -1,0 +1,17 @@
+package com.pedro.rtmp.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AuthUtilTest {
+
+    @Test
+    fun `when list of numbers converted to hex, then correct concatenated hex returned`() {
+        val numbersToHex = mapOf(
+            255 to "ff", 128 to "80", 8 to "08", 1 to "01", 0 to "00", -255 to "01", -1 to "ff"
+        )
+        val testBytes = numbersToHex.keys.map { it.toByte()}.toByteArray()
+        val expectedHex = numbersToHex.values.reduce { acc, s -> acc + s }
+        assertEquals(expectedHex, AuthUtil.bytesToHex(testBytes))
+    }
+}


### PR DESCRIPTION
Hi @pedroSG94 
Looks like the `AuthUtil.bytesToHex()` didn't work well resulting in llnw streams failing.
I was getting IndexOutOfBoundException in this line ```hexChars[j * 2] = hexArray[v ushr 4]```
I suppose that converting mask to byte wasn't necessary.