### PR TITLE
Default RTMPS port to 443

### DIFF
--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
@@ -172,7 +172,7 @@ class RtmpClient(private val connectCheckerRtmp: ConnectCheckerRtmp) {
 
       commandsManager.host = rtmpMatcher.group(1) ?: ""
       val portStr = rtmpMatcher.group(2)
-      commandsManager.port = portStr?.toInt() ?: 1935
+      commandsManager.port = portStr?.toInt() ?: if (tlsEnabled) 443 else 1935
       commandsManager.appName = getAppName(rtmpMatcher.group(3) ?: "", rtmpMatcher.group(4) ?: "")
       commandsManager.streamName = getStreamName(rtmpMatcher.group(4) ?: "")
       commandsManager.tcUrl = getTcUrl((rtmpMatcher.group(0)

--- a/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
+++ b/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
@@ -158,7 +158,7 @@ open class RtspClient(private val connectCheckerRtsp: ConnectCheckerRtsp) {
         return
       }
       val host = rtspMatcher.group(1) ?: ""
-      val port: Int = (rtspMatcher.group(2) ?: "554").toInt()
+      val port: Int = rtmpMatcher.group(2)?.toInt() ?: if (tlsEnabled) 443 else 554
       val streamName = if (rtspMatcher.group(4).isNullOrEmpty()) "" else "/" + rtspMatcher.group(4)
       val path = "/" + rtspMatcher.group(3) + streamName
 


### PR DESCRIPTION
Often, RTMPS URLs are provided externally and it should not be necessary to inject a port number into them before this library can use them.