### PR TITLE
BaseRecordController

### DIFF
--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
@@ -49,8 +49,10 @@ import com.pedro.encoder.utils.CodecUtil;
 import com.pedro.encoder.video.FormatVideoEncoder;
 import com.pedro.encoder.video.GetVideoData;
 import com.pedro.encoder.video.VideoEncoder;
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+import com.pedro.rtplibrary.base.recording.Status;
+import com.pedro.rtplibrary.util.AndroidMuxerRecordController;
 import com.pedro.rtplibrary.util.FpsListener;
-import com.pedro.rtplibrary.util.RecordController;
 import com.pedro.rtplibrary.view.GlInterface;
 import com.pedro.rtplibrary.view.LightOpenGlView;
 import com.pedro.rtplibrary.view.OffScreenGlThread;
@@ -87,7 +89,7 @@ public abstract class Camera1Base
   private boolean streaming = false;
   private boolean audioInitialized = false;
   private boolean onPreview = false;
-  protected RecordController recordController;
+  protected BaseRecordController recordController;
   private int previewWidth, previewHeight;
   private final FpsListener fpsListener = new FpsListener();
 
@@ -133,7 +135,7 @@ public abstract class Camera1Base
   private void init() {
     videoEncoder = new VideoEncoder(this);
     setMicrophoneMode(MicrophoneMode.ASYNC);
-    recordController = new RecordController();
+    recordController = new AndroidMuxerRecordController();
   }
 
   /**
@@ -372,7 +374,7 @@ public abstract class Camera1Base
    * @throws IOException If initialized before a stream.
    */
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-  public void startRecord(@NonNull final String path, @Nullable RecordController.Listener listener)
+  public void startRecord(@NonNull final String path, @Nullable BaseRecordController.Listener listener)
       throws IOException {
     recordController.startRecord(path, listener);
     if (!streaming) {
@@ -395,7 +397,7 @@ public abstract class Camera1Base
    */
   @RequiresApi(api = Build.VERSION_CODES.O)
   public void startRecord(@NonNull final FileDescriptor fd,
-      @Nullable RecordController.Listener listener) throws IOException {
+      @Nullable BaseRecordController.Listener listener) throws IOException {
     recordController.startRecord(fd, listener);
     if (!streaming) {
       startEncoders();
@@ -607,7 +609,7 @@ public abstract class Camera1Base
   }
 
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-  public void startStreamAndRecord(String url, String path, RecordController.Listener listener) throws IOException {
+  public void startStreamAndRecord(String url, String path, BaseRecordController.Listener listener) throws IOException {
     startStream(url);
     recordController.startRecord(path, listener);
   }
@@ -919,7 +921,7 @@ public abstract class Camera1Base
     recordController.resumeRecord();
   }
 
-  public RecordController.Status getRecordStatus() {
+  public Status getRecordStatus() {
     return recordController.getStatus();
   }
 
@@ -969,6 +971,10 @@ public abstract class Camera1Base
   @Override
   public void onAudioFormat(MediaFormat mediaFormat) {
     recordController.setAudioFormat(mediaFormat);
+  }
+
+  public void setRecordController(BaseRecordController recordController) {
+    this.recordController = recordController;
   }
 
   public abstract void setLogs(boolean enable);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera2Base.java
@@ -50,8 +50,11 @@ import com.pedro.encoder.utils.CodecUtil;
 import com.pedro.encoder.video.FormatVideoEncoder;
 import com.pedro.encoder.video.GetVideoData;
 import com.pedro.encoder.video.VideoEncoder;
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+import com.pedro.rtplibrary.base.recording.RecordController;
+import com.pedro.rtplibrary.base.recording.Status;
+import com.pedro.rtplibrary.util.AndroidMuxerRecordController;
 import com.pedro.rtplibrary.util.FpsListener;
-import com.pedro.rtplibrary.util.RecordController;
 import com.pedro.rtplibrary.view.GlInterface;
 import com.pedro.rtplibrary.view.LightOpenGlView;
 import com.pedro.rtplibrary.view.OffScreenGlThread;
@@ -90,7 +93,7 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
   private boolean audioInitialized = false;
   private boolean onPreview = false;
   private boolean isBackground = false;
-  protected RecordController recordController;
+  protected BaseRecordController recordController;
   private int previewWidth, previewHeight;
   private final FpsListener fpsListener = new FpsListener();
 
@@ -146,7 +149,7 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
     cameraManager = new Camera2ApiManager(context);
     videoEncoder = new VideoEncoder(this);
     setMicrophoneMode(MicrophoneMode.ASYNC);
-    recordController = new RecordController();
+    recordController = new AndroidMuxerRecordController();
   }
 
   /**
@@ -434,7 +437,7 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
    */
   @RequiresApi(api = Build.VERSION_CODES.O)
   public void startRecord(@NonNull final FileDescriptor fd,
-      @Nullable RecordController.Listener listener) throws IOException {
+      @Nullable AndroidMuxerRecordController.Listener listener) throws IOException {
     recordController.startRecord(fd, listener);
     if (!streaming) {
       startEncoders();
@@ -608,7 +611,7 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
     }
   }
 
-  public void startStreamAndRecord(String url, String path, RecordController.Listener listener) throws IOException {
+  public void startStreamAndRecord(String url, String path, AndroidMuxerRecordController.Listener listener) throws IOException {
     startStream(url);
     recordController.startRecord(path, listener);
   }
@@ -1007,7 +1010,7 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
     recordController.resumeRecord();
   }
 
-  public RecordController.Status getRecordStatus() {
+  public Status getRecordStatus() {
     return recordController.getStatus();
   }
 
@@ -1057,6 +1060,10 @@ public abstract class Camera2Base implements GetAacData, GetVideoData, GetMicrop
   @Override
   public void onAudioFormat(MediaFormat mediaFormat) {
     recordController.setAudioFormat(mediaFormat);
+  }
+
+  public void setRecordController(BaseRecordController recordController) {
+    this.recordController = recordController;
   }
 
   public abstract void setLogs(boolean enable);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/DisplayBase.java
@@ -44,8 +44,10 @@ import com.pedro.encoder.utils.CodecUtil;
 import com.pedro.encoder.video.FormatVideoEncoder;
 import com.pedro.encoder.video.GetVideoData;
 import com.pedro.encoder.video.VideoEncoder;
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+import com.pedro.rtplibrary.base.recording.Status;
 import com.pedro.rtplibrary.util.FpsListener;
-import com.pedro.rtplibrary.util.RecordController;
+import com.pedro.rtplibrary.util.AndroidMuxerRecordController;
 import com.pedro.rtplibrary.view.GlInterface;
 import com.pedro.rtplibrary.view.OffScreenGlThread;
 
@@ -78,7 +80,7 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
   private int dpi = 320;
   private int resultCode = -1;
   private Intent data;
-  protected RecordController recordController;
+  protected BaseRecordController recordController;
   private final FpsListener fpsListener = new FpsListener();
   private boolean audioInitialized = false;
 
@@ -94,7 +96,7 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
     audioEncoder = new AudioEncoder(this);
     //Necessary use same thread to read input buffer and encode it with internal audio or audio is choppy.
     setMicrophoneMode(MicrophoneMode.SYNC);
-    recordController = new RecordController();
+    recordController = new AndroidMuxerRecordController();
   }
 
   /**
@@ -295,7 +297,7 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
    * @param path Where file will be saved.
    * @throws IOException If initialized before a stream.
    */
-  public void startRecord(@NonNull String path, @Nullable RecordController.Listener listener)
+  public void startRecord(@NonNull String path, @Nullable AndroidMuxerRecordController.Listener listener)
       throws IOException {
     recordController.startRecord(path, listener);
     if (!streaming) {
@@ -317,7 +319,7 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
    */
   @RequiresApi(api = Build.VERSION_CODES.O)
   public void startRecord(@NonNull final FileDescriptor fd,
-      @Nullable RecordController.Listener listener) throws IOException {
+      @Nullable AndroidMuxerRecordController.Listener listener) throws IOException {
     recordController.startRecord(fd, listener);
     if (!streaming) {
       startEncoders(resultCode, data);
@@ -574,7 +576,7 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
     recordController.resumeRecord();
   }
 
-  public RecordController.Status getRecordStatus() {
+  public Status getRecordStatus() {
     return recordController.getStatus();
   }
 
@@ -615,6 +617,10 @@ public abstract class DisplayBase implements GetAacData, GetVideoData, GetMicrop
   @Override
   public void onAudioFormat(MediaFormat mediaFormat) {
     recordController.setAudioFormat(mediaFormat);
+  }
+
+  public void setRecordController(BaseRecordController recordController) {
+    this.recordController = recordController;
   }
 
   public abstract void setLogs(boolean enable);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/FromFileBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/FromFileBase.java
@@ -41,8 +41,10 @@ import com.pedro.encoder.utils.CodecUtil;
 import com.pedro.encoder.video.FormatVideoEncoder;
 import com.pedro.encoder.video.GetVideoData;
 import com.pedro.encoder.video.VideoEncoder;
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+import com.pedro.rtplibrary.base.recording.Status;
 import com.pedro.rtplibrary.util.FpsListener;
-import com.pedro.rtplibrary.util.RecordController;
+import com.pedro.rtplibrary.util.AndroidMuxerRecordController;
 import com.pedro.rtplibrary.view.GlInterface;
 import com.pedro.rtplibrary.view.LightOpenGlView;
 import com.pedro.rtplibrary.view.OffScreenGlThread;
@@ -72,7 +74,7 @@ public abstract class FromFileBase
   private AudioEncoder audioEncoder;
   private GlInterface glInterface;
   private boolean streaming = false;
-  protected RecordController recordController;
+  protected BaseRecordController recordController;
   private final FpsListener fpsListener = new FpsListener();
 
   private VideoDecoder videoDecoder;
@@ -124,7 +126,7 @@ public abstract class FromFileBase
     audioEncoder = new AudioEncoder(this);
     videoDecoder = new VideoDecoder(videoDecoderInterface, this);
     audioDecoder = new AudioDecoder(this, audioDecoderInterface, this);
-    recordController = new RecordController();
+    recordController = new AndroidMuxerRecordController();
   }
 
   /**
@@ -236,7 +238,7 @@ public abstract class FromFileBase
    * @param path Where file will be saved.
    * @throws IOException If initialized before a stream.
    */
-  public void startRecord(@NonNull String path, @Nullable RecordController.Listener listener) throws IOException {
+  public void startRecord(@NonNull String path, @Nullable AndroidMuxerRecordController.Listener listener) throws IOException {
     recordController.startRecord(path, listener);
     if (!streaming) {
       startEncoders();
@@ -256,7 +258,7 @@ public abstract class FromFileBase
    * @throws IOException If initialized before a stream.
    */
   @RequiresApi(api = Build.VERSION_CODES.O)
-  public void startRecord(@NonNull final FileDescriptor fd, @Nullable RecordController.Listener listener) throws IOException {
+  public void startRecord(@NonNull final FileDescriptor fd, @Nullable AndroidMuxerRecordController.Listener listener) throws IOException {
     recordController.startRecord(fd, listener);
     if (!streaming) {
       startEncoders();
@@ -559,7 +561,7 @@ public abstract class FromFileBase
     recordController.resumeRecord();
   }
 
-  public RecordController.Status getRecordStatus() {
+  public Status getRecordStatus() {
     return recordController.getStatus();
   }
 
@@ -679,6 +681,10 @@ public abstract class FromFileBase
       audioTrackPlayer.write(frame.getBuffer(), frame.getOffset(), frame.getSize());
     }
     audioEncoder.inputPCMData(frame);
+  }
+
+  public void setRecordController(BaseRecordController recordController) {
+    this.recordController = recordController;
   }
 
   public abstract void setLogs(boolean enable);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/OnlyAudioBase.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/OnlyAudioBase.java
@@ -32,7 +32,9 @@ import com.pedro.encoder.input.audio.GetMicrophoneData;
 import com.pedro.encoder.input.audio.MicrophoneManager;
 import com.pedro.encoder.input.audio.MicrophoneManagerManual;
 import com.pedro.encoder.input.audio.MicrophoneMode;
-import com.pedro.rtplibrary.util.RecordController;
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+import com.pedro.rtplibrary.base.recording.Status;
+import com.pedro.rtplibrary.util.AndroidMuxerRecordController;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -45,14 +47,14 @@ import java.nio.ByteBuffer;
  */
 public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
 
-  private final RecordController recordController;
+  protected BaseRecordController recordController;
   private MicrophoneManager microphoneManager;
   private AudioEncoder audioEncoder;
   private boolean streaming = false;
 
   public OnlyAudioBase() {
     setMicrophoneMode(MicrophoneMode.ASYNC);
-    recordController = new RecordController();
+    recordController = new AndroidMuxerRecordController();
   }
 
   /**
@@ -150,7 +152,7 @@ public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
    * @throws IOException If initialized before a stream.
    */
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-  public void startRecord(String path, RecordController.Listener listener) throws IOException {
+  public void startRecord(String path, AndroidMuxerRecordController.Listener listener) throws IOException {
     recordController.startRecord(path, listener);
     if (!streaming) {
       startEncoders();
@@ -170,7 +172,7 @@ public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
    */
   @RequiresApi(api = Build.VERSION_CODES.O)
   public void startRecord(@NonNull final FileDescriptor fd,
-      @Nullable RecordController.Listener listener) throws IOException {
+      @Nullable AndroidMuxerRecordController.Listener listener) throws IOException {
     recordController.startRecord(fd, listener);
     if (!streaming) {
       startEncoders();
@@ -249,7 +251,7 @@ public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
     recordController.resumeRecord();
   }
 
-  public RecordController.Status getRecordStatus() {
+  public Status getRecordStatus() {
     return recordController.getStatus();
   }
 
@@ -349,6 +351,10 @@ public abstract class OnlyAudioBase implements GetAacData, GetMicrophoneData {
   @Override
   public void onAudioFormat(MediaFormat mediaFormat) {
     recordController.setAudioFormat(mediaFormat, true);
+  }
+
+  public void setRecordController(BaseRecordController recordController) {
+    this.recordController = recordController;
   }
 
   public abstract void setLogs(boolean enable);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/recording/BaseRecordController.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/recording/BaseRecordController.java
@@ -1,0 +1,114 @@
+package com.pedro.rtplibrary.base.recording;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+
+import androidx.annotation.CallSuper;
+
+import com.pedro.encoder.utils.CodecUtil;
+import com.pedro.rtsp.utils.RtpConstants;
+
+import java.nio.ByteBuffer;
+
+public abstract class BaseRecordController implements RecordController {
+
+    protected Status status = Status.STOPPED;
+    protected String videoMime = CodecUtil.H264_MIME;
+    protected long pauseMoment = 0;
+    protected long pauseTime = 0;
+    protected Listener listener;
+    protected int videoTrack = -1;
+    protected int audioTrack = -1;
+    protected final MediaCodec.BufferInfo videoInfo = new MediaCodec.BufferInfo();
+    protected final MediaCodec.BufferInfo audioInfo = new MediaCodec.BufferInfo();
+
+
+
+    public boolean isRunning() {
+        return status == Status.STARTED
+                || status == Status.RECORDING
+                || status == Status.RESUMED
+                || status == Status.PAUSED;
+    }
+
+    public boolean isRecording() {
+        return status == Status.RECORDING;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    @Override
+    public void resetFormats() {
+
+    }
+
+    public abstract void init();
+
+    public void pauseRecord() {
+        if (status == Status.RECORDING) {
+            pauseMoment = System.nanoTime() / 1000;
+            status = Status.PAUSED;
+            if (listener != null) listener.onStatusChange(status);
+        }
+    }
+
+    public void resumeRecord() {
+        if (status == Status.PAUSED) {
+            pauseTime += System.nanoTime() / 1000 - pauseMoment;
+            status = Status.RESUMED;
+            if (listener != null) listener.onStatusChange(status);
+        }
+    }
+
+    @Override
+    public void setVideoMime(String videoMime) {
+
+    }
+
+
+    @Override
+    public void setAudioFormat(MediaFormat audioFormat) {
+
+    }
+
+    @Override
+    public void setVideoFormat(MediaFormat videoFormat, boolean isOnlyVideo) {
+
+    }
+
+    @Override
+    public void setAudioFormat(MediaFormat audioFormat, boolean isOnlyVideo) {
+
+    }
+
+    @Override
+    @CallSuper
+    public void stopRecord() {
+        videoTrack = -1;
+        audioTrack = -1;
+    }
+
+    protected boolean isKeyFrame(ByteBuffer videoBuffer) {
+        byte[] header = new byte[5];
+        videoBuffer.duplicate().get(header, 0, header.length);
+        if (videoMime.equals(CodecUtil.H264_MIME) && (header[4] & 0x1F) == RtpConstants.IDR) {  //h264
+            return true;
+        } else { //h265
+            return videoMime.equals(CodecUtil.H265_MIME)
+                    && ((header[4] >> 1) & 0x3f) == RtpConstants.IDR_W_DLP
+                    || ((header[4] >> 1) & 0x3f) == RtpConstants.IDR_N_LP;
+        }
+    }
+
+    //We can't reuse info because could produce stream issues
+    protected void updateFormat(MediaCodec.BufferInfo newInfo, MediaCodec.BufferInfo oldInfo) {
+        newInfo.flags = oldInfo.flags;
+        newInfo.offset = oldInfo.offset;
+        newInfo.size = oldInfo.size;
+        newInfo.presentationTimeUs = oldInfo.presentationTimeUs - pauseTime;
+    }
+
+
+}

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/recording/RecordController.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/recording/RecordController.java
@@ -1,0 +1,38 @@
+package com.pedro.rtplibrary.base.recording;
+
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public interface RecordController {
+
+    void startRecord(@NonNull String path, @Nullable Listener listener) throws IOException;
+    void startRecord(@NonNull FileDescriptor fd, @Nullable Listener listener) throws IOException;
+    void recordVideo(ByteBuffer videoBuffer, MediaCodec.BufferInfo videoInfo);
+    void recordAudio(ByteBuffer audioBuffer, MediaCodec.BufferInfo audioInfo);
+    void setVideoFormat(MediaFormat videoFormat, boolean isOnlyVideo);
+    void setAudioFormat(MediaFormat audioFormat);
+    void setAudioFormat(MediaFormat audioFormat,boolean isOnlyVideo);
+    void write(int track, ByteBuffer byteBuffer, MediaCodec.BufferInfo info);
+    void stopRecord();
+    boolean isRunning();
+    boolean isRecording();
+    void setVideoMime(String videoMime);
+    Status getStatus();
+    void resetFormats();
+    void pauseRecord();
+    void resumeRecord();
+
+    public interface Listener {
+        void onStatusChange(Status status);
+    }
+
+}

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/recording/Status.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/recording/Status.java
@@ -1,0 +1,5 @@
+package com.pedro.rtplibrary.base.recording;
+
+public enum Status {
+ STARTED, STOPPED, RECORDING, PAUSED, RESUMED
+}

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/util/AndroidMuxerRecordController.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/util/AndroidMuxerRecordController.java
@@ -25,8 +25,10 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
-import com.pedro.encoder.utils.CodecUtil;
-import com.pedro.rtsp.utils.RtpConstants;
+
+
+import com.pedro.rtplibrary.base.recording.BaseRecordController;
+import com.pedro.rtplibrary.base.recording.Status;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
@@ -37,31 +39,22 @@ import java.nio.ByteBuffer;
  *
  * Class to control video recording with MediaMuxer.
  */
-public class RecordController {
+public class AndroidMuxerRecordController extends BaseRecordController {
 
-  private static final String TAG = "RecordController";
-  private Status status = Status.STOPPED;
+  private static final String TAG = "AndroidRecordController";
   private MediaMuxer mediaMuxer;
   private MediaFormat videoFormat, audioFormat;
-  private int videoTrack = -1;
-  private int audioTrack = -1;
-  private Listener listener;
   //Pause/Resume
   private long pauseMoment = 0;
   private long pauseTime = 0;
   private final MediaCodec.BufferInfo videoInfo = new MediaCodec.BufferInfo();
   private final MediaCodec.BufferInfo audioInfo = new MediaCodec.BufferInfo();
-  private String videoMime = CodecUtil.H264_MIME;
   private boolean isOnlyAudio = false;
   private boolean isOnlyVideo = false;
 
-  public enum Status {
-    STARTED, STOPPED, RECORDING, PAUSED, RESUMED
-  }
 
-  public interface Listener {
-    void onStatusChange(Status status);
-  }
+
+
 
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
   public void startRecord(@NonNull String path, @Nullable Listener listener) throws IOException {
@@ -83,6 +76,7 @@ public class RecordController {
 
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
   public void stopRecord() {
+    super.stopRecord();
     status = Status.STOPPED;
     if (mediaMuxer != null) {
       try {
@@ -92,8 +86,6 @@ public class RecordController {
       }
     }
     mediaMuxer = null;
-    videoTrack = -1;
-    audioTrack = -1;
     pauseMoment = 0;
     pauseTime = 0;
     if (listener != null) listener.onStatusChange(status);
@@ -103,56 +95,18 @@ public class RecordController {
     this.videoMime = videoMime;
   }
 
-  public boolean isRunning() {
-    return status == Status.STARTED
-        || status == Status.RECORDING
-        || status == Status.RESUMED
-        || status == Status.PAUSED;
-  }
 
-  public boolean isRecording() {
-    return status == Status.RECORDING;
-  }
-
-  public Status getStatus() {
-    return status;
-  }
 
   public void resetFormats() {
     videoFormat = null;
     audioFormat = null;
   }
 
-  public void pauseRecord() {
-    if (status == Status.RECORDING) {
-      pauseMoment = System.nanoTime() / 1000;
-      status = Status.PAUSED;
-      if (listener != null) listener.onStatusChange(status);
-    }
-  }
 
-  public void resumeRecord() {
-    if (status == Status.PAUSED) {
-      pauseTime += System.nanoTime() / 1000 - pauseMoment;
-      status = Status.RESUMED;
-      if (listener != null) listener.onStatusChange(status);
-    }
-  }
-
-  private boolean isKeyFrame(ByteBuffer videoBuffer) {
-    byte[] header = new byte[5];
-    videoBuffer.duplicate().get(header, 0, header.length);
-    if (videoMime.equals(CodecUtil.H264_MIME) && (header[4] & 0x1F) == RtpConstants.IDR) {  //h264
-      return true;
-    } else { //h265
-      return videoMime.equals(CodecUtil.H265_MIME)
-          && ((header[4] >> 1) & 0x3f) == RtpConstants.IDR_W_DLP
-          || ((header[4] >> 1) & 0x3f) == RtpConstants.IDR_N_LP;
-    }
-  }
 
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-  private void write(int track, ByteBuffer byteBuffer, MediaCodec.BufferInfo info) {
+  @Override
+  public void write(int track, ByteBuffer byteBuffer, MediaCodec.BufferInfo info) {
     try {
       mediaMuxer.writeSampleData(track, byteBuffer, info);
     } catch (IllegalStateException | IllegalArgumentException e) {
@@ -161,7 +115,7 @@ public class RecordController {
   }
 
   @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN_MR2)
-  private void init() {
+  public void init() {
     if (!isOnlyVideo) audioTrack = mediaMuxer.addTrack(audioFormat);
     mediaMuxer.start();
     status = Status.RECORDING;
@@ -176,7 +130,7 @@ public class RecordController {
         init();
       }
     } else if (status == Status.RESUMED && (videoInfo.flags == MediaCodec.BUFFER_FLAG_KEY_FRAME
-        || isKeyFrame(videoBuffer))) {
+            || isKeyFrame(videoBuffer))) {
       status = Status.RECORDING;
       if (listener != null) listener.onStatusChange(status);
     }
@@ -203,7 +157,7 @@ public class RecordController {
     this.audioFormat = audioFormat;
     this.isOnlyAudio = isOnlyAudio;
     if (isOnlyAudio && status == Status.STARTED
-        && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
       init();
     }
   }
@@ -216,11 +170,4 @@ public class RecordController {
     setAudioFormat(audioFormat, false);
   }
 
-  //We can't reuse info because could produce stream issues
-  private void updateFormat(MediaCodec.BufferInfo newInfo, MediaCodec.BufferInfo oldInfo) {
-    newInfo.flags = oldInfo.flags;
-    newInfo.offset = oldInfo.offset;
-    newInfo.size = oldInfo.size;
-    newInfo.presentationTimeUs = oldInfo.presentationTimeUs - pauseTime;
-  }
 }


### PR DESCRIPTION
Created the BaseRecordController component to allow setting up a custom RecordController to record video in other formats that accept h264 and aac or in mp4 using something different from AndroidMuxer (Xuggler or JCodec for example)
By default the AndroidMuxerRecordController class is used.