### PR TITLE
allow selection of all cameras with camera1

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
@@ -135,19 +135,21 @@ public class Camera1ApiManager implements Camera.PreviewCallback, Camera.FaceDet
     facing = cameraFacing;
   }
 
-  public void start(CameraHelper.Facing cameraFacing, int width, int height, int fps) {
-    int facing = cameraFacing == CameraHelper.Facing.BACK ? Camera.CameraInfo.CAMERA_FACING_BACK
-        : Camera.CameraInfo.CAMERA_FACING_FRONT;
+  public void setCameraSelect(int cameraFacing) {
+    cameraSelect = cameraFacing;
+  }
+
+  public void start(int facing, int width, int height, int fps) {
     this.width = width;
     this.height = height;
     this.fps = fps;
-    cameraSelect =
-        facing == Camera.CameraInfo.CAMERA_FACING_BACK ? selectCameraBack() : selectCameraFront();
+    cameraSelect = facing;
+    selectCamera(facing);
     start();
   }
 
   public void start(int width, int height, int fps) {
-    start(facing, width, height, fps);
+    start(cameraSelect, width, height, fps);
   }
 
   private void start() {

--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
@@ -139,6 +139,17 @@ public class Camera1ApiManager implements Camera.PreviewCallback, Camera.FaceDet
     cameraSelect = cameraFacing;
   }
 
+  public void start(CameraHelper.Facing cameraFacing, int width, int height, int fps) {
+    int facing = cameraFacing == CameraHelper.Facing.BACK ? Camera.CameraInfo.CAMERA_FACING_BACK
+            : Camera.CameraInfo.CAMERA_FACING_FRONT;
+    this.width = width;
+    this.height = height;
+    this.fps = fps;
+    cameraSelect =
+            facing == Camera.CameraInfo.CAMERA_FACING_BACK ? selectCameraBack() : selectCameraFront();
+    start();
+  }
+
   public void start(int facing, int width, int height, int fps) {
     this.width = width;
     this.height = height;

--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera1ApiManager.java
@@ -492,6 +492,20 @@ public class Camera1ApiManager implements Camera.PreviewCallback, Camera.FaceDet
     }
   }
 
+  public void switchCamera(int cameraId) throws CameraOpenException {
+    if (camera != null) {
+      int oldCamera = cameraSelect;
+      cameraSelect = cameraId;
+      if (!checkCanOpen()) {
+        cameraSelect = oldCamera;
+        throw new CameraOpenException("This camera resolution cant be opened");
+      }
+      stop();
+      start();
+      return;
+    }
+  }
+
   private boolean checkCanOpen() {
     List<Camera.Size> previews;
     if (cameraSelect == selectCameraBack()) {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/base/Camera1Base.java
@@ -890,6 +890,14 @@ public abstract class Camera1Base
     }
   }
 
+  public void switchCamera(int cameraId) throws CameraOpenException {
+    if (isStreaming() || onPreview) {
+      cameraManager.switchCamera(cameraId);
+    } else {
+      cameraManager.setCameraSelect(cameraId);
+    }
+  }
+
   public void setExposure(int value) {
     cameraManager.setExposure(value);
   }

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/util/sources/VideoManager.kt
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/util/sources/VideoManager.kt
@@ -97,7 +97,7 @@ class VideoManager(private val context: Context, private var source: Source) {
         Source.CAMERA1 -> {
           surfaceTexture.setDefaultBufferSize(width, height)
           camera1.setSurfaceTexture(surfaceTexture)
-          camera1.start(facing, width, height, fps)
+          camera1.start(facing.ordinal, width, height, fps)
           camera1.setPreviewOrientation(90) // necessary to use the same orientation than camera2
         }
         Source.CAMERA2 -> {

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/util/sources/VideoManager.kt
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/util/sources/VideoManager.kt
@@ -97,7 +97,7 @@ class VideoManager(private val context: Context, private var source: Source) {
         Source.CAMERA1 -> {
           surfaceTexture.setDefaultBufferSize(width, height)
           camera1.setSurfaceTexture(surfaceTexture)
-          camera1.start(facing.ordinal, width, height, fps)
+          camera1.start(facing, width, height, fps)
           camera1.setPreviewOrientation(90) // necessary to use the same orientation than camera2
         }
         Source.CAMERA2 -> {


### PR DESCRIPTION
Hi, I would like to use any camera using camera1 api.

This uses `cameraSelect` outside of Camera1Base

I found that VideoManager.kt needs a modification to work with my changes, should I keep the original `start()` to avoid any breakage ? 