### PR TITLE
Allow video only mode in RtspCamera2

### DIFF
--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera1.java
@@ -81,6 +81,13 @@ public class RtmpCamera1 extends Camera1Base {
     rtmpClient.setProfileIop(profileIop);
   }
 
+  /**
+   * Must be called before connect
+   */
+  public void setOnlyVideo(Boolean onlyVideo) {
+    rtmpClient.setOnlyVideo(onlyVideo);
+  }
+
   @Override
   public void resizeCache(int newSize) throws RuntimeException {
     rtmpClient.resizeCache(newSize);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtmp/RtmpCamera2.java
@@ -92,6 +92,13 @@ public class RtmpCamera2 extends Camera2Base {
     rtmpClient.setProfileIop(profileIop);
   }
 
+  /**
+   * Must be called before connect
+   */
+  public void setOnlyVideo(Boolean onlyVideo) {
+    rtmpClient.setOnlyVideo(onlyVideo);
+  }
+
   @Override
   public void resizeCache(int newSize) throws RuntimeException {
     rtmpClient.resizeCache(newSize);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera1.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera1.java
@@ -82,6 +82,13 @@ public class RtspCamera1 extends Camera1Base {
     rtspClient.setProtocol(protocol);
   }
 
+  /**
+   * Must be called before connect
+   */
+  public void setOnlyVideo(Boolean onlyVideo) {
+    rtspClient.setOnlyVideo(onlyVideo);
+  }
+
   @Override
   public void resizeCache(int newSize) throws RuntimeException {
     rtspClient.resizeCache(newSize);

--- a/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
+++ b/rtplibrary/src/main/java/com/pedro/rtplibrary/rtsp/RtspCamera2.java
@@ -93,6 +93,13 @@ public class RtspCamera2 extends Camera2Base {
     rtspClient.setProtocol(protocol);
   }
 
+  /**
+   * Must be called before connect
+   */
+  public void setOnlyVideo(Boolean onlyVideo) {
+    rtspClient.setOnlyVideo(onlyVideo);
+  }
+
   @Override
   public void resizeCache(int newSize) throws RuntimeException {
     rtspClient.resizeCache(newSize);


### PR DESCRIPTION
Hi Pedro, at first I would like to thank you for the great library! It makes our lives easier ❤️ 

The current `RtspCamera2` version does not allow to enable video only mode and the only way to achieve it is to implement your own `Camera2Base`. I don't see any reason why this couldn't be added so hence my PR.

Tell me what do you think.