### PR TITLE
Update RtmpClient.kt

### DIFF
--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
@@ -475,6 +475,8 @@ class RtmpClient(private val connectCheckerRtmp: ConnectCheckerRtmp) {
         }
       } catch (e: IOException) {
         Log.e(TAG, "disconnect error", e)
+      } finally {
+        closeConnection()
       }
     }
     try {
@@ -483,8 +485,6 @@ class RtmpClient(private val connectCheckerRtmp: ConnectCheckerRtmp) {
       thread?.awaitTermination(100, TimeUnit.MILLISECONDS)
       thread = null
     } catch (e: Exception) {
-    } finally {
-      closeConnection()
     }
     if (clear) {
       reTries = numRetry


### PR DESCRIPTION
Do not call closeConnection() on main thread
    
NetworkOnMainThreadException is thrown without this fix.